### PR TITLE
fix(task): deregister output on task stop to prevent kafka connection leak

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24 as builder
+FROM golang:1.16 as builder
 ARG VERSION=7.3.1
 WORKDIR /workspace
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as builder
+FROM golang:1.24 as builder
 ARG VERSION=7.3.1
 WORKDIR /workspace
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.11
 
 require (
-	github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse v1.9.0
+	github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse v1.9.1-alpha.1
 	github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils v0.3.0
 	github.com/bytedance/sonic v1.12.10
 	github.com/dustin/go-humanize v1.0.0
@@ -116,6 +116,6 @@ require (
 
 replace (
 	github.com/Sirupsen/logrus v1.6.0 => github.com/sirupsen/logrus v1.9.3
-	github.com/elastic/beats v7.1.1+incompatible => github.com/TencentBlueking/beats v7.1.50-bk+incompatible
+	github.com/elastic/beats v7.1.1+incompatible => github.com/TencentBlueking/beats v7.1.52-bk-alpha.1+incompatible
 	github.com/sirupsen/logrus v1.8.1 => github.com/sirupsen/logrus v1.9.3
 )

--- a/go.sum
+++ b/go.sum
@@ -41,12 +41,14 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWso
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
-github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse v1.9.0 h1:wL28QB10MG/mFJn6zf0NJ8CjULpNKGoJ+cZ7xDFwPOU=
-github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse v1.9.0/go.mod h1:gDiD8QFEEugzdlgdm7MGPp1szzwgKca0FZkhmTZ67Y0=
+github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse v1.9.1-alpha.1 h1:kJH1OBDFj+lHSYPcxN/JAlZV5XbPWgGB8wDi0WcZ7B8=
+github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse v1.9.1-alpha.1/go.mod h1:gDiD8QFEEugzdlgdm7MGPp1szzwgKca0FZkhmTZ67Y0=
 github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils v0.3.0 h1:M22V54nzKf4jReUWp9+rF0255nvlQP/B4zzuXIGyBlU=
 github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils v0.3.0/go.mod h1:ETap19QgROaVGv9E9MRtWMeOgx/gbhbtzcjk4cgadoM=
 github.com/TencentBlueking/beats v7.1.50-bk+incompatible h1:L/MVkPv4RR7OJWbGM2WcK0hgnlAqjbnBRmUdGa7sdQg=
 github.com/TencentBlueking/beats v7.1.50-bk+incompatible/go.mod h1:tJ6ZFzI1DAUQUUyvPBYVlmGBuH3QKGDK9mwN4LBg+Os=
+github.com/TencentBlueking/beats v7.1.52-bk-alpha.1+incompatible h1:HXk6/LeOoDc2FFWElt8SSiYEOjrm25sWpxnm8FTAAx8=
+github.com/TencentBlueking/beats v7.1.52-bk-alpha.1+incompatible/go.mod h1:tJ6ZFzI1DAUQUUyvPBYVlmGBuH3QKGDK9mwN4LBg+Os=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/task/task.go
+++ b/task/task.go
@@ -122,6 +122,10 @@ func (task *Task) Stop() error {
 	task.ParentNode.RemoveOutput(task.Node)
 	task.ParentNode.RemoveTaskNode(task.Node, task.TaskNode)
 
+	if task.Config.Output.Name() != "" {
+		bkpipe_multi.DeregisterTaskOutput(task.Config.ID)
+	}
+
 	logp.L.Infof("task(%s) is remove", task.ID)
 	task.CloseOnce.Do(func() {
 		close(task.End)


### PR DESCRIPTION
## Summary

修复任务卸载/重载时 Kafka 连接泄漏问题。

`Task.Stop()` 缺少对 `bkpipe_multi.DeregisterTaskOutput()` 的调用，导致 `taskRegistry` 和 `outputRegistry` 中的记录永远不会被清理，Kafka client 不会被 Close，TCP 连接持续累积。

修复：在 `Stop()` 中、关闭 `task.End` 之前，调用 `bkpipe_multi.DeregisterTaskOutput(task.Config.ID)` 进行反注册。

> **依赖**：需配合 `bkmonitor-datalink` 侧 `DeregisterTaskOutput` 函数的新增（TencentBlueKing/bkmonitor-datalink PR），libgse 发版后需升级 go.mod 依赖。

## Test plan

- [ ] 配置一个带 `output.kafka` 的子配置任务
- [ ] 多次触发配置重载（删除/修改子配置文件）
- [ ] 通过 `ss -tnp | grep 9092` 或 `netstat` 观察 Kafka TCP 连接数，确认重载后旧连接释放
- [ ] 升级 libgse 依赖后执行 `go build ./...` 编译通过

Made with [Cursor](https://cursor.com)