### PR TITLE
feat: 主配置变量(max_procs/file_identifier)补齐至全部平台插件包模板

### DIFF
--- a/support-files/templates/aix/powerpc/etc/bkunifylogbeat_main.conf.tpl
+++ b/support-files/templates/aix/powerpc/etc/bkunifylogbeat_main.conf.tpl
@@ -1,5 +1,9 @@
 logging.level: error
+{%- if extra_vars is defined and extra_vars.max_procs is defined %}
+max_procs: {{ extra_vars.max_procs | default(1, true) }}
+{%- else %}
 max_procs: 1
+{%- endif %}
 output.bkpipe_multi:
   endpoint: {{ plugin_path.endpoint }}
 {%- if nodeman is defined %}
@@ -42,6 +46,11 @@ bkunifylogbeat.multi_config:
     file_pattern: "*.conf"
   - path: {{ plugin_path.subconfig_path }}/bcs
     file_pattern: "*.conf"
+{%- if extra_vars is defined and extra_vars.file_identifier is defined %}
+bkunifylogbeat.file_identifier: {{ extra_vars.file_identifier | default("inode", true) }}
+{%- else %}
+bkunifylogbeat.file_identifier: "inode"
+{%- endif %}
 
 {% if cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
 {%- set resource_limit = resource_limit | default({}) -%}

--- a/support-files/templates/aix/powerpc/project.yaml
+++ b/support-files/templates/aix/powerpc/project.yaml
@@ -19,6 +19,22 @@ config_templates:
     format: yaml
     is_main_config: 1
     source_path: etc/bkunifylogbeat_main.conf.tpl
+    variables:
+      type: object
+      title: variables
+      properties:
+        extra_vars:
+          title: extra_vars
+          type: object
+          properties:
+            max_procs:
+              title: "MaxProcs(CPU 最大使用核数)"
+              type: number
+              default: 1
+            file_identifier:
+              title: "FileIdentifier(文件识别模式，inode/path)"
+              type: string
+              default: "inode"
   - plugin_version: "*"
     name: bkunifylogbeat.conf
     version: 1

--- a/support-files/templates/linux/aarch64/etc/bkunifylogbeat_main.conf.tpl
+++ b/support-files/templates/linux/aarch64/etc/bkunifylogbeat_main.conf.tpl
@@ -1,5 +1,9 @@
 logging.level: error
+{%- if extra_vars is defined and extra_vars.max_procs is defined %}
+max_procs: {{ extra_vars.max_procs | default(1, true) }}
+{%- else %}
 max_procs: 1
+{%- endif %}
 output.bkpipe_multi:
   endpoint: {{ plugin_path.endpoint }}
 {%- if nodeman is defined %}
@@ -42,6 +46,11 @@ bkunifylogbeat.multi_config:
     file_pattern: "*.conf"
   - path: {{ plugin_path.subconfig_path }}/bcs
     file_pattern: "*.conf"
+{%- if extra_vars is defined and extra_vars.file_identifier is defined %}
+bkunifylogbeat.file_identifier: {{ extra_vars.file_identifier | default("inode", true) }}
+{%- else %}
+bkunifylogbeat.file_identifier: "inode"
+{%- endif %}
 
 {% if cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
 {%- set resource_limit = resource_limit | default({}) -%}

--- a/support-files/templates/linux/aarch64/project.yaml
+++ b/support-files/templates/linux/aarch64/project.yaml
@@ -19,6 +19,22 @@ config_templates:
     format: yaml
     is_main_config: 1
     source_path: etc/bkunifylogbeat_main.conf.tpl
+    variables:
+      type: object
+      title: variables
+      properties:
+        extra_vars:
+          title: extra_vars
+          type: object
+          properties:
+            max_procs:
+              title: "MaxProcs(CPU 最大使用核数)"
+              type: number
+              default: 1
+            file_identifier:
+              title: "FileIdentifier(文件识别模式，inode/path)"
+              type: string
+              default: "inode"
   - plugin_version: "*"
     name: bkunifylogbeat.conf
     version: 1

--- a/support-files/templates/linux/x86/etc/bkunifylogbeat_main.conf.tpl
+++ b/support-files/templates/linux/x86/etc/bkunifylogbeat_main.conf.tpl
@@ -1,5 +1,9 @@
 logging.level: error
+{%- if extra_vars is defined and extra_vars.max_procs is defined %}
+max_procs: {{ extra_vars.max_procs | default(1, true) }}
+{%- else %}
 max_procs: 1
+{%- endif %}
 output.bkpipe_multi:
   endpoint: {{ plugin_path.endpoint }}
 {%- if nodeman is defined %}
@@ -42,6 +46,11 @@ bkunifylogbeat.multi_config:
     file_pattern: "*.conf"
   - path: {{ plugin_path.subconfig_path }}/bcs
     file_pattern: "*.conf"
+{%- if extra_vars is defined and extra_vars.file_identifier is defined %}
+bkunifylogbeat.file_identifier: {{ extra_vars.file_identifier | default("inode", true) }}
+{%- else %}
+bkunifylogbeat.file_identifier: "inode"
+{%- endif %}
 
 {% if cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
 {%- set resource_limit = resource_limit | default({}) -%}

--- a/support-files/templates/linux/x86/project.yaml
+++ b/support-files/templates/linux/x86/project.yaml
@@ -19,6 +19,22 @@ config_templates:
     format: yaml
     is_main_config: 1
     source_path: etc/bkunifylogbeat_main.conf.tpl
+    variables:
+      type: object
+      title: variables
+      properties:
+        extra_vars:
+          title: extra_vars
+          type: object
+          properties:
+            max_procs:
+              title: "MaxProcs(CPU 最大使用核数)"
+              type: number
+              default: 1
+            file_identifier:
+              title: "FileIdentifier(文件识别模式，inode/path)"
+              type: string
+              default: "inode"
   - plugin_version: "*"
     name: bkunifylogbeat.conf
     version: 1

--- a/support-files/templates/windows/x86/etc/bkunifylogbeat_main.conf.tpl
+++ b/support-files/templates/windows/x86/etc/bkunifylogbeat_main.conf.tpl
@@ -1,5 +1,9 @@
 logging.level: error
+{%- if extra_vars is defined and extra_vars.max_procs is defined %}
+max_procs: {{ extra_vars.max_procs | default(1, true) }}
+{%- else %}
 max_procs: 1
+{%- endif %}
 output.bkpipe_multi:
   endpoint: {{ plugin_path.endpoint }}
 {%- if nodeman is defined %}
@@ -42,6 +46,11 @@ bkunifylogbeat.multi_config:
     file_pattern: "*.conf"
   - path: {{ plugin_path.subconfig_path }}\bcs
     file_pattern: "*.conf"
+{%- if extra_vars is defined and extra_vars.file_identifier is defined %}
+bkunifylogbeat.file_identifier: {{ extra_vars.file_identifier | default("inode", true) }}
+{%- else %}
+bkunifylogbeat.file_identifier: "inode"
+{%- endif %}
 
 {% if cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
 {%- set resource_limit = resource_limit | default({}) -%}

--- a/support-files/templates/windows/x86/project.yaml
+++ b/support-files/templates/windows/x86/project.yaml
@@ -19,6 +19,22 @@ config_templates:
     format: yaml
     is_main_config: 1
     source_path: etc/bkunifylogbeat_main.conf.tpl
+    variables:
+      type: object
+      title: variables
+      properties:
+        extra_vars:
+          title: extra_vars
+          type: object
+          properties:
+            max_procs:
+              title: "MaxProcs(CPU 最大使用核数)"
+              type: number
+              default: 1
+            file_identifier:
+              title: "FileIdentifier(文件识别模式，inode/path)"
+              type: string
+              default: "inode"
   - plugin_version: "*"
     name: bkunifylogbeat.conf
     version: 1

--- a/support-files/templates/windows/x86_64/etc/bkunifylogbeat_main.conf.tpl
+++ b/support-files/templates/windows/x86_64/etc/bkunifylogbeat_main.conf.tpl
@@ -1,5 +1,9 @@
 logging.level: error
+{%- if extra_vars is defined and extra_vars.max_procs is defined %}
+max_procs: {{ extra_vars.max_procs | default(1, true) }}
+{%- else %}
 max_procs: 1
+{%- endif %}
 output.bkpipe_multi:
   endpoint: {{ plugin_path.endpoint }}
 {%- if nodeman is defined %}
@@ -42,6 +46,11 @@ bkunifylogbeat.multi_config:
     file_pattern: "*.conf"
   - path: {{ plugin_path.subconfig_path }}\bcs
     file_pattern: "*.conf"
+{%- if extra_vars is defined and extra_vars.file_identifier is defined %}
+bkunifylogbeat.file_identifier: {{ extra_vars.file_identifier | default("inode", true) }}
+{%- else %}
+bkunifylogbeat.file_identifier: "inode"
+{%- endif %}
 
 {% if cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
 {%- set resource_limit = resource_limit | default({}) -%}

--- a/support-files/templates/windows/x86_64/project.yaml
+++ b/support-files/templates/windows/x86_64/project.yaml
@@ -19,6 +19,22 @@ config_templates:
     format: yaml
     is_main_config: 1
     source_path: etc/bkunifylogbeat_main.conf.tpl
+    variables:
+      type: object
+      title: variables
+      properties:
+        extra_vars:
+          title: extra_vars
+          type: object
+          properties:
+            max_procs:
+              title: "MaxProcs(CPU 最大使用核数)"
+              type: number
+              default: 1
+            file_identifier:
+              title: "FileIdentifier(文件识别模式，inode/path)"
+              type: string
+              default: "inode"
   - plugin_version: "*"
     name: bkunifylogbeat.conf
     version: 1


### PR DESCRIPTION
## 问题

节点管理插件包参数模板中无法选择 `file_identifier` 与 `max_proc`(max_procs)。

## 根因

`#131`（commit 7bb6b38「支持注入主配置变量」）仅修改了 `linux/x86_64` 的两个文件：
- `support-files/templates/linux/x86_64/project.yaml`：新增 `config_templates[主配置].variables.extra_vars`（max_procs/file_identifier）参数 schema
- `support-files/templates/linux/x86_64/etc/bkunifylogbeat_main.conf.tpl`：`extra_vars` 条件注入

其余 5 个平台（`linux/x86`、`linux/aarch64`、`windows/x86_64`、`windows/x86`、`aix/powerpc`）的插件包仍缺少 `variables` 定义，`max_procs` 写死、且无 `file_identifier` 行。

节点管理按 os/cpu_arch 各注册一份主配置模板，多平台 schema 不一致时会解析到「无 variables」版本，导致这两个参数在参数模板里不可选。

## 改动

将 `variables` 块与 `extra_vars` 条件注入对齐补齐到全部 6 个平台：
- 6 × `project.yaml`：主配置模板下统一 `extra_vars.{max_procs, file_identifier}` schema
- 6 × `bkunifylogbeat_main.conf.tpl`：`max_procs` 改为 `extra_vars.max_procs` 条件注入；新增 `bkunifylogbeat.file_identifier` 的 `extra_vars.file_identifier` 条件注入

默认值保持 `max_procs=1`、`file_identifier=inode`，不改变现有渲染行为；非 x86_64 平台仅本次新增（x86_64 无改动）。

## 验证

- [ ] 各平台 `project.yaml` YAML 合法、`variables` 一致
- [ ] 出包后在节点管理重新导入插件包，确认主配置参数模板可选择 `max_procs` / `file_identifier`
- [ ] 新建订阅，确认下发渲染正确（默认值与自定义值）

Made with [Cursor](https://cursor.com)