### PR TITLE
feat: 提高主配置 resource_limit 默认上限 (cpu 1→4 core, mem 1000→4096 MB)

### DIFF
--- a/support-files/templates/aix/powerpc/etc/bkunifylogbeat_main.conf.tpl
+++ b/support-files/templates/aix/powerpc/etc/bkunifylogbeat_main.conf.tpl
@@ -62,7 +62,7 @@ resource_limit:
         cmdb_instance.host.bk_cpu * resource_limit.get('cpu', {}).get('percentage', 0.1),
         resource_limit.get('cpu', {}).get('min', 0.1)
       ] | max,
-      resource_limit.get('cpu', {}).get('max', 1)
+      resource_limit.get('cpu', {}).get('max', 4)
     ] | min
   }}
   mem: {{
@@ -71,7 +71,7 @@ resource_limit:
         cmdb_instance.host.bk_mem * resource_limit.get('mem', {}).get('percentage', 0.1),
         resource_limit.get('mem', {}).get('min', 100)
       ] | max,
-        resource_limit.get('mem', {}).get('max', 1000)
+        resource_limit.get('mem', {}).get('max', 4096)
     ] | min | int
   }}
 {% endif %}

--- a/support-files/templates/linux/aarch64/etc/bkunifylogbeat_main.conf.tpl
+++ b/support-files/templates/linux/aarch64/etc/bkunifylogbeat_main.conf.tpl
@@ -62,7 +62,7 @@ resource_limit:
         cmdb_instance.host.bk_cpu * resource_limit.get('cpu', {}).get('percentage', 0.1),
         resource_limit.get('cpu', {}).get('min', 0.1)
       ] | max,
-      resource_limit.get('cpu', {}).get('max', 1)
+      resource_limit.get('cpu', {}).get('max', 4)
     ] | min
   }}
   mem: {{
@@ -71,7 +71,7 @@ resource_limit:
         cmdb_instance.host.bk_mem * resource_limit.get('mem', {}).get('percentage', 0.1),
         resource_limit.get('mem', {}).get('min', 100)
       ] | max,
-        resource_limit.get('mem', {}).get('max', 1000)
+        resource_limit.get('mem', {}).get('max', 4096)
     ] | min | int
   }}
 {% endif %}

--- a/support-files/templates/linux/x86/etc/bkunifylogbeat_main.conf.tpl
+++ b/support-files/templates/linux/x86/etc/bkunifylogbeat_main.conf.tpl
@@ -62,7 +62,7 @@ resource_limit:
         cmdb_instance.host.bk_cpu * resource_limit.get('cpu', {}).get('percentage', 0.1),
         resource_limit.get('cpu', {}).get('min', 0.1)
       ] | max,
-      resource_limit.get('cpu', {}).get('max', 1)
+      resource_limit.get('cpu', {}).get('max', 4)
     ] | min
   }}
   mem: {{
@@ -71,7 +71,7 @@ resource_limit:
         cmdb_instance.host.bk_mem * resource_limit.get('mem', {}).get('percentage', 0.1),
         resource_limit.get('mem', {}).get('min', 100)
       ] | max,
-        resource_limit.get('mem', {}).get('max', 1000)
+        resource_limit.get('mem', {}).get('max', 4096)
     ] | min | int
   }}
 {% endif %}

--- a/support-files/templates/linux/x86_64/etc/bkunifylogbeat_main.conf.tpl
+++ b/support-files/templates/linux/x86_64/etc/bkunifylogbeat_main.conf.tpl
@@ -62,7 +62,7 @@ resource_limit:
         cmdb_instance.host.bk_cpu * resource_limit.get('cpu', {}).get('percentage', 0.1),
         resource_limit.get('cpu', {}).get('min', 0.1)
       ] | max,
-      resource_limit.get('cpu', {}).get('max', 1)
+      resource_limit.get('cpu', {}).get('max', 4)
     ] | min
   }}
   mem: {{
@@ -71,7 +71,7 @@ resource_limit:
         cmdb_instance.host.bk_mem * resource_limit.get('mem', {}).get('percentage', 0.1),
         resource_limit.get('mem', {}).get('min', 100)
       ] | max,
-        resource_limit.get('mem', {}).get('max', 1000)
+        resource_limit.get('mem', {}).get('max', 4096)
     ] | min | int
   }}
 {% endif %}

--- a/support-files/templates/windows/x86/etc/bkunifylogbeat_main.conf.tpl
+++ b/support-files/templates/windows/x86/etc/bkunifylogbeat_main.conf.tpl
@@ -62,7 +62,7 @@ resource_limit:
         cmdb_instance.host.bk_cpu * resource_limit.get('cpu', {}).get('percentage', 0.1),
         resource_limit.get('cpu', {}).get('min', 0.1)
       ] | max,
-      resource_limit.get('cpu', {}).get('max', 1)
+      resource_limit.get('cpu', {}).get('max', 4)
     ] | min
   }}
   mem: {{
@@ -71,7 +71,7 @@ resource_limit:
         cmdb_instance.host.bk_mem * resource_limit.get('mem', {}).get('percentage', 0.1),
         resource_limit.get('mem', {}).get('min', 100)
       ] | max,
-        resource_limit.get('mem', {}).get('max', 1000)
+        resource_limit.get('mem', {}).get('max', 4096)
     ] | min | int
   }}
 {% endif %}

--- a/support-files/templates/windows/x86_64/etc/bkunifylogbeat_main.conf.tpl
+++ b/support-files/templates/windows/x86_64/etc/bkunifylogbeat_main.conf.tpl
@@ -62,7 +62,7 @@ resource_limit:
         cmdb_instance.host.bk_cpu * resource_limit.get('cpu', {}).get('percentage', 0.1),
         resource_limit.get('cpu', {}).get('min', 0.1)
       ] | max,
-      resource_limit.get('cpu', {}).get('max', 1)
+      resource_limit.get('cpu', {}).get('max', 4)
     ] | min
   }}
   mem: {{
@@ -71,7 +71,7 @@ resource_limit:
         cmdb_instance.host.bk_mem * resource_limit.get('mem', {}).get('percentage', 0.1),
         resource_limit.get('mem', {}).get('min', 100)
       ] | max,
-        resource_limit.get('mem', {}).get('max', 1000)
+        resource_limit.get('mem', {}).get('max', 4096)
     ] | min | int
   }}
 {% endif %}


### PR DESCRIPTION
## 背景

节点管理主配置模板 `bkunifylogbeat_main.conf.tpl` 里的 `resource_limit` 采用「按主机规格自适应 + 上下限兜底」公式：

```
cpu = min( max(主机核数 × percentage, min), max )
mem = min( max(主机内存 × percentage, min), max )
```

原默认 `max` 封顶偏低（cpu 1 核 / mem 1000 MB），在大规格主机、日志量较大的场景下采集器容易被限到打满而丢数据。

## 改动

仅上调封顶默认值，`percentage`(0.1) 与 `min`(0.1 核 / 100 MB) 保持不变：

- cpu `max`: `1` → `4`（core）
- mem `max`: `1000` → `4096`（MB）

## 平台一致性

6 个平台模板同步修改，保证节点管理插件包参数跨平台一致：

- `linux/x86_64`、`linux/x86`、`linux/aarch64`
- `windows/x86_64`、`windows/x86`
- `aix/powerpc`

## 说明

- 这是**上限**（cgroup 天花板），不是资源申请；仅在大主机 + 高负载时才会用到更高的额度。
- `mem` 限制仅在 Linux 通过 cgroup 生效；非 Linux 平台只有 `cpu` 经 `GOMAXPROCS` 生效。
- 三个值仍支持通过注入 `resource_limit` 变量覆盖，本次只调整默认值。

Made with [Cursor](https://cursor.com)