### PR TITLE
feat: bump beats to v7.1.53-bk for literal path fast walk --story=135803621

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -116,6 +116,6 @@ require (
 
 replace (
 	github.com/Sirupsen/logrus v1.6.0 => github.com/sirupsen/logrus v1.9.3
-	github.com/elastic/beats v7.1.1+incompatible => github.com/TencentBlueking/beats v7.1.52-bk-alpha.1+incompatible
+	github.com/elastic/beats v7.1.1+incompatible => github.com/TencentBlueking/beats v7.1.53-bk+incompatible
 	github.com/sirupsen/logrus v1.8.1 => github.com/sirupsen/logrus v1.9.3
 )

--- a/go.sum
+++ b/go.sum
@@ -45,10 +45,8 @@ github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse v1.9.1-alpha.1 h1:kJH1O
 github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse v1.9.1-alpha.1/go.mod h1:gDiD8QFEEugzdlgdm7MGPp1szzwgKca0FZkhmTZ67Y0=
 github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils v0.3.0 h1:M22V54nzKf4jReUWp9+rF0255nvlQP/B4zzuXIGyBlU=
 github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils v0.3.0/go.mod h1:ETap19QgROaVGv9E9MRtWMeOgx/gbhbtzcjk4cgadoM=
-github.com/TencentBlueking/beats v7.1.50-bk+incompatible h1:L/MVkPv4RR7OJWbGM2WcK0hgnlAqjbnBRmUdGa7sdQg=
-github.com/TencentBlueking/beats v7.1.50-bk+incompatible/go.mod h1:tJ6ZFzI1DAUQUUyvPBYVlmGBuH3QKGDK9mwN4LBg+Os=
-github.com/TencentBlueking/beats v7.1.52-bk-alpha.1+incompatible h1:HXk6/LeOoDc2FFWElt8SSiYEOjrm25sWpxnm8FTAAx8=
-github.com/TencentBlueking/beats v7.1.52-bk-alpha.1+incompatible/go.mod h1:tJ6ZFzI1DAUQUUyvPBYVlmGBuH3QKGDK9mwN4LBg+Os=
+github.com/TencentBlueking/beats v7.1.53-bk+incompatible h1:5uzFBednpBEEpL5yhrNA+AdzX3G/aLnSDyNLrtN7qPI=
+github.com/TencentBlueking/beats v7.1.53-bk+incompatible/go.mod h1:tJ6ZFzI1DAUQUUyvPBYVlmGBuH3QKGDK9mwN4LBg+Os=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=


### PR DESCRIPTION
## Summary
- 将 `go.mod` 中 `TencentBlueking/beats` 从 `v7.1.52-bk-alpha.1` 升级到 `v7.1.53-bk`
- 接入字面路径层级跳过 `ReadDir` 的扫描优化，降低大祖先目录下的扫描固定开销

TAPD: https://tapd.woa.com/tapd_fe/10158081/story/detail/1010158081135803621

Beats PR: https://github.com/TencentBlueKing/beats/pull/49

## Test plan
- [x] `go mod tidy` / `go build ./` 通过
- [x] 确认 `v7.1.53-bk` 模块内含字面路径快路径实现
- [ ] 合入后按需做采集回归（字面路径 / glob / 挂载 / 软链场景）