### PR TITLE
feat: 支持自适应文件扫描周期

### DIFF
--- a/beater/manager.go
+++ b/beater/manager.go
@@ -201,6 +201,8 @@ func (m *Manager) Reload(config cfg.Config) {
 // 新控制器会先完成校验和启动；创建失败时直接返回，旧控制器继续工作。
 // 替换时依次卸载 hooks、断开清理通知、停止旧控制器，最后安装新控制器，
 // 确保 Interval 与 Applied 始终属于同一代配置。
+// 已经进入等待的 Runner 不会被 Reload 唤醒；当前等待到期并完成扫描后，
+// Runner 才读取新 hooks 计算后续周期，这是自适应配置约定的下一轮生效语义。
 func (m *Manager) configureAdaptiveScan(config cfg.AdaptiveScanConfig) error {
 	m.adaptiveScanMu.Lock()
 	defer m.adaptiveScanMu.Unlock()

--- a/beater/manager.go
+++ b/beater/manager.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse/logp"
 	bkmonitoring "github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse/monitoring"
+	filebeatinput "github.com/elastic/beats/filebeat/input"
 	"github.com/elastic/beats/filebeat/input/file"
 	"github.com/elastic/beats/libbeat/monitoring"
 
@@ -54,14 +55,20 @@ type Manager struct {
 	config   cfg.Config
 	wg       sync.WaitGroup
 	beatDone chan struct{}
+
+	adaptiveScan             *utils.AdaptiveScanController
+	adaptiveScanConfig       cfg.AdaptiveScanConfig
+	adaptiveScanMu           sync.Mutex
+	setAdaptiveScanHooksFunc func(filebeatinput.AdaptiveScanHooks)
 }
 
 // NewManager create new manager
 func NewManager(config cfg.Config, beatDone chan struct{}) (*Manager, error) {
 	m := &Manager{
-		config:   config,
-		beatDone: beatDone,
-		tasks:    make(map[string]*task.Task),
+		config:                   config,
+		beatDone:                 beatDone,
+		tasks:                    make(map[string]*task.Task),
+		setAdaptiveScanHooksFunc: filebeatinput.SetAdaptiveScanHooks,
 	}
 
 	return m, nil
@@ -73,6 +80,9 @@ func (m *Manager) Start() error {
 	logp.L.Info("start manager")
 
 	utils.SetResourceLimit(m.config.MaxCpuLimit, m.config.CpuCheckTimes)
+	if err = m.configureAdaptiveScan(m.config.AdaptiveScan); err != nil {
+		return err
+	}
 
 	// Task
 	lastStates := registrar.ResetStates(Registrar.GetStates())
@@ -90,6 +100,7 @@ func (m *Manager) Start() error {
 
 // Stop Close manager when program quit
 func (m *Manager) Stop() error {
+	_ = m.configureAdaptiveScan(cfg.AdaptiveScanConfig{Enabled: false})
 	for _, t := range m.tasks {
 		t.Stop()
 		m.wg.Done()
@@ -104,6 +115,9 @@ func (m *Manager) Reload(config cfg.Config) {
 	logp.L.Infof("[Reload]update config, current tasks=>%d", len(m.tasks))
 
 	utils.SetResourceLimit(config.MaxCpuLimit, config.CpuCheckTimes)
+	if err := m.configureAdaptiveScan(config.AdaptiveScan); err != nil {
+		logp.L.Errorf("configure adaptive scan failed: %v", err)
+	}
 
 	lastStates := registrar.ResetStates(Registrar.GetStates())
 	newTasks := cfg.GetTasks(config)
@@ -179,6 +193,50 @@ func (m *Manager) Reload(config cfg.Config) {
 
 	//step 5: 重设beats配置
 	m.config = config
+}
+
+func (m *Manager) configureAdaptiveScan(config cfg.AdaptiveScanConfig) error {
+	m.adaptiveScanMu.Lock()
+	defer m.adaptiveScanMu.Unlock()
+
+	if m.setAdaptiveScanHooksFunc == nil {
+		m.setAdaptiveScanHooksFunc = filebeatinput.SetAdaptiveScanHooks
+	}
+	if config.Enabled && m.adaptiveScan != nil && m.adaptiveScanConfig == config {
+		return nil
+	}
+
+	var controller *utils.AdaptiveScanController
+	if config.Enabled {
+		var err error
+		controller, err = utils.NewAdaptiveScanController(utils.AdaptiveScanSettings{
+			MinScanFrequency: config.MinScanFrequency,
+			ScanCPUPercent:   config.ScanCPUPercent,
+			ControlInterval:  config.ControlInterval,
+		})
+		if err != nil {
+			return fmt.Errorf("create adaptive scan controller: %w", err)
+		}
+		controller.Start()
+	}
+
+	// 计算与最终结果通知必须整组卸载，避免 Reload 窗口内出现新旧回调错配。
+	m.setAdaptiveScanHooksFunc(filebeatinput.AdaptiveScanHooks{})
+	utils.SetActiveAdaptiveScanController(nil)
+	if m.adaptiveScan != nil {
+		m.adaptiveScan.Stop()
+	}
+	m.adaptiveScan = controller
+	m.adaptiveScanConfig = cfg.AdaptiveScanConfig{}
+	if controller != nil {
+		m.adaptiveScanConfig = config
+		utils.SetActiveAdaptiveScanController(controller)
+		m.setAdaptiveScanHooksFunc(filebeatinput.AdaptiveScanHooks{
+			Interval: controller.NextInterval,
+			Applied:  controller.ObserveApplied,
+		})
+	}
+	return nil
 }
 
 // startTask 启动任务，调用filebeat.runner开始进行日志采集

--- a/beater/manager.go
+++ b/beater/manager.go
@@ -56,6 +56,7 @@ type Manager struct {
 	wg       sync.WaitGroup
 	beatDone chan struct{}
 
+	// 自适应扫描控制器由 Manager 独占管理；配置锁保证并发 Reload 时只会有一条替换链路。
 	adaptiveScan             *utils.AdaptiveScanController
 	adaptiveScanConfig       cfg.AdaptiveScanConfig
 	adaptiveScanMu           sync.Mutex
@@ -100,6 +101,7 @@ func (m *Manager) Start() error {
 
 // Stop Close manager when program quit
 func (m *Manager) Stop() error {
+	// 先卸载 hooks，再停止 Task，避免 Runner 退出期间继续调用即将销毁的控制器。
 	_ = m.configureAdaptiveScan(cfg.AdaptiveScanConfig{Enabled: false})
 	for _, t := range m.tasks {
 		t.Stop()
@@ -195,6 +197,10 @@ func (m *Manager) Reload(config cfg.Config) {
 	m.config = config
 }
 
+// configureAdaptiveScan 以完整 hooks bundle 为单位替换自适应扫描控制器。
+// 新控制器会先完成校验和启动；创建失败时直接返回，旧控制器继续工作。
+// 替换时依次卸载 hooks、断开清理通知、停止旧控制器，最后安装新控制器，
+// 确保 Interval 与 Applied 始终属于同一代配置。
 func (m *Manager) configureAdaptiveScan(config cfg.AdaptiveScanConfig) error {
 	m.adaptiveScanMu.Lock()
 	defer m.adaptiveScanMu.Unlock()
@@ -208,6 +214,7 @@ func (m *Manager) configureAdaptiveScan(config cfg.AdaptiveScanConfig) error {
 
 	var controller *utils.AdaptiveScanController
 	if config.Enabled {
+		// 先构造新实例，不提前破坏当前可用配置，避免一次无效 Reload 关闭既有能力。
 		var err error
 		controller, err = utils.NewAdaptiveScanController(utils.AdaptiveScanSettings{
 			MinScanFrequency: config.MinScanFrequency,
@@ -231,6 +238,7 @@ func (m *Manager) configureAdaptiveScan(config cfg.AdaptiveScanConfig) error {
 	if controller != nil {
 		m.adaptiveScanConfig = config
 		utils.SetActiveAdaptiveScanController(controller)
+		// Beats 最终裁决周期后通过 Applied 回传，日志记录的才是 Runner 实际等待周期。
 		m.setAdaptiveScanHooksFunc(filebeatinput.AdaptiveScanHooks{
 			Interval: controller.NextInterval,
 			Applied:  controller.ObserveApplied,

--- a/beater/manager_test.go
+++ b/beater/manager_test.go
@@ -1,0 +1,141 @@
+// Tencent is pleased to support the open source community by making bkunifylogbeat 蓝鲸日志采集器 available.
+//
+// Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License.
+
+package beater
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/filebeat/input"
+	"github.com/stretchr/testify/assert"
+
+	cfg "github.com/TencentBlueKing/bkunifylogbeat/config"
+)
+
+func TestManagerConfigureAdaptiveScan(t *testing.T) {
+	var installed input.AdaptiveScanHooks
+	setterCalls := 0
+	manager := &Manager{
+		setAdaptiveScanHooksFunc: func(hooks input.AdaptiveScanHooks) {
+			setterCalls++
+			installed = hooks
+		},
+	}
+
+	config := cfg.AdaptiveScanConfig{
+		Enabled:          true,
+		MinScanFrequency: 500 * time.Millisecond,
+		ScanCPUPercent:   5,
+		ControlInterval:  3 * time.Second,
+	}
+	err := manager.configureAdaptiveScan(config)
+	assert.NoError(t, err)
+	assert.NotNil(t, manager.adaptiveScan)
+	assert.NotNil(t, installed.Interval)
+	assert.NotNil(t, installed.Applied)
+	requested := installed.Interval(1, 10*time.Second, time.Millisecond)
+	assert.Equal(t, 500*time.Millisecond, requested)
+	installed.Applied(1, 10*time.Second, requested, requested, time.Millisecond)
+
+	controller := manager.adaptiveScan
+	callsAfterFirstConfigure := setterCalls
+	err = manager.configureAdaptiveScan(config)
+	assert.NoError(t, err)
+	assert.Same(t, controller, manager.adaptiveScan)
+	assert.Equal(t, callsAfterFirstConfigure, setterCalls)
+
+	err = manager.configureAdaptiveScan(cfg.AdaptiveScanConfig{Enabled: false})
+	assert.NoError(t, err)
+	assert.Nil(t, manager.adaptiveScan)
+	assert.Nil(t, installed.Interval)
+	assert.Nil(t, installed.Applied)
+}
+
+func TestManagerConfigureAdaptiveScanRejectsInvalidConfig(t *testing.T) {
+	var installed input.AdaptiveScanHooks
+	manager := &Manager{
+		setAdaptiveScanHooksFunc: func(hooks input.AdaptiveScanHooks) {
+			installed = hooks
+		},
+	}
+
+	err := manager.configureAdaptiveScan(cfg.AdaptiveScanConfig{
+		Enabled:          true,
+		MinScanFrequency: 0,
+		ScanCPUPercent:   5,
+		ControlInterval:  time.Second,
+	})
+
+	assert.Error(t, err)
+	assert.Nil(t, manager.adaptiveScan)
+	assert.Nil(t, installed.Interval)
+	assert.Nil(t, installed.Applied)
+}
+
+func TestManagerConfigureAdaptiveScanKeepsOldControllerWhenReplacementIsInvalid(t *testing.T) {
+	var installed input.AdaptiveScanHooks
+	manager := &Manager{
+		setAdaptiveScanHooksFunc: func(hooks input.AdaptiveScanHooks) {
+			installed = hooks
+		},
+	}
+	valid := cfg.AdaptiveScanConfig{
+		Enabled:          true,
+		MinScanFrequency: 500 * time.Millisecond,
+		ScanCPUPercent:   5,
+		ControlInterval:  time.Second,
+	}
+	assert.NoError(t, manager.configureAdaptiveScan(valid))
+	oldController := manager.adaptiveScan
+
+	err := manager.configureAdaptiveScan(cfg.AdaptiveScanConfig{
+		Enabled:          true,
+		MinScanFrequency: 0,
+		ScanCPUPercent:   5,
+		ControlInterval:  time.Second,
+	})
+
+	assert.Error(t, err)
+	assert.Same(t, oldController, manager.adaptiveScan)
+	assert.NotNil(t, installed.Interval)
+	assert.NotNil(t, installed.Applied)
+	assert.NoError(t, manager.configureAdaptiveScan(cfg.AdaptiveScanConfig{Enabled: false}))
+}
+
+func TestManagerConfigureAdaptiveScanSerializesConcurrentReplacement(t *testing.T) {
+	manager := &Manager{
+		setAdaptiveScanHooksFunc: func(input.AdaptiveScanHooks) {},
+	}
+	configs := []cfg.AdaptiveScanConfig{
+		{
+			Enabled:          true,
+			MinScanFrequency: 500 * time.Millisecond,
+			ScanCPUPercent:   5,
+			ControlInterval:  time.Second,
+		},
+		{
+			Enabled:          true,
+			MinScanFrequency: time.Second,
+			ScanCPUPercent:   10,
+			ControlInterval:  2 * time.Second,
+		},
+		{Enabled: false},
+	}
+
+	var wg sync.WaitGroup
+	for index := 0; index < 30; index++ {
+		wg.Add(1)
+		go func(config cfg.AdaptiveScanConfig) {
+			defer wg.Done()
+			assert.NoError(t, manager.configureAdaptiveScan(config))
+		}(configs[index%len(configs)])
+	}
+	wg.Wait()
+
+	assert.NoError(t, manager.configureAdaptiveScan(cfg.AdaptiveScanConfig{Enabled: false}))
+	assert.Nil(t, manager.adaptiveScan)
+}

--- a/bkunifylogbeat.reference.yml
+++ b/bkunifylogbeat.reference.yml
@@ -21,6 +21,13 @@ bkunifylogbeat.buffertimeout: 2
 bkunifylogbeat.eventdataid: -1
 bkunifylogbeat.max_cpu_limit: -1
 bkunifylogbeat.cpu_check_times: 10
+# 根据实际扫描耗时动态缩短各文件 input 的扫描周期，并将聚合扫描开销
+# 控制在配置的单核 CPU 预算内。默认关闭。
+#bkunifylogbeat.adaptive_scan:
+#  enabled: false
+#  min_scan_frequency: "500ms"
+#  scan_cpu_percent: 5
+#  control_interval: "3s"
 bkunifylogbeat.multi_config:
   - path: "/usr/local/gse/plugins/etc/bkunifylogbeat"
     file_pattern: "*.conf"

--- a/bkunifylogbeat.reference.yml
+++ b/bkunifylogbeat.reference.yml
@@ -22,10 +22,10 @@ bkunifylogbeat.eventdataid: -1
 bkunifylogbeat.max_cpu_limit: -1
 bkunifylogbeat.cpu_check_times: 10
 # 根据实际扫描耗时动态缩短各文件 input 的扫描周期，并将聚合扫描开销
-# 控制在配置的单核 CPU 预算内。默认关闭。
+# 控制在配置的单核 CPU 预算内。默认开启。
 #bkunifylogbeat.adaptive_scan:
-#  enabled: false
-#  min_scan_frequency: "500ms"
+#  enabled: true
+#  min_scan_frequency: "1s"
 #  scan_cpu_percent: 5
 #  control_interval: "3s"
 bkunifylogbeat.multi_config:

--- a/config/config.go
+++ b/config/config.go
@@ -140,10 +140,10 @@ func Parse(cfg *beat.Config) (Config, error) {
 		BufferTimeout: 1,
 		MaxCpuLimit:   -1,
 		CpuCheckTimes: 10,
-		// 默认关闭；其余值仅作为启用后的保守起步参数。
+		// 默认开启，并使用 1 秒最小周期和 5% 单核预算作为保守起步参数。
 		AdaptiveScan: AdaptiveScanConfig{
-			Enabled:          false,
-			MinScanFrequency: 500 * time.Millisecond,
+			Enabled:          true,
+			MinScanFrequency: time.Second,
 			ScanCPUPercent:   5,
 			ControlInterval:  3 * time.Second,
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse/beat"
@@ -42,6 +43,8 @@ type Config struct {
 	MaxCpuLimit int `config:"max_cpu_limit"` // 最大CPU限制，仅在某些极端情况下开启
 	// CpuCheckTimes
 	CpuCheckTimes int `config:"cpu_check_times"` // 1秒内检测多少次CPU, 可选值，[1-10]
+	// AdaptiveScan 动态扫描周期配置
+	AdaptiveScan AdaptiveScanConfig `config:"adaptive_scan"`
 
 	// SecConfigs sec config path and pattern
 	SecConfigs []SecConfigItem `config:"multi_config"`
@@ -61,6 +64,31 @@ type Config struct {
 
 	// 采集状态的唯一标识符
 	FileIdentifier string `config:"file_identifier"`
+}
+
+// AdaptiveScanConfig 控制扫描周期自适应及其全局 CPU 预算。
+type AdaptiveScanConfig struct {
+	Enabled          bool          `config:"enabled"`
+	MinScanFrequency time.Duration `config:"min_scan_frequency"`
+	ScanCPUPercent   float64       `config:"scan_cpu_percent"`
+	ControlInterval  time.Duration `config:"control_interval"`
+}
+
+func (c AdaptiveScanConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.MinScanFrequency <= 0 {
+		return fmt.Errorf("adaptive_scan.min_scan_frequency must be greater than 0")
+	}
+	if c.ScanCPUPercent <= 0 || c.ScanCPUPercent > 100 ||
+		math.IsNaN(c.ScanCPUPercent) || math.IsInf(c.ScanCPUPercent, 0) {
+		return fmt.Errorf("adaptive_scan.scan_cpu_percent must be greater than 0 and no more than 100")
+	}
+	if c.ControlInterval <= 0 {
+		return fmt.Errorf("adaptive_scan.control_interval must be greater than 0")
+	}
+	return nil
 }
 
 // 从配置目录
@@ -109,6 +137,12 @@ func Parse(cfg *beat.Config) (Config, error) {
 		BufferTimeout: 1,
 		MaxCpuLimit:   -1,
 		CpuCheckTimes: 10,
+		AdaptiveScan: AdaptiveScanConfig{
+			Enabled:          false,
+			MinScanFrequency: 500 * time.Millisecond,
+			ScanCPUPercent:   5,
+			ControlInterval:  3 * time.Second,
+		},
 		Registry: Registry{
 			FlushTimeout: 1 * time.Second,
 			GcFrequency:  1 * time.Minute,
@@ -121,6 +155,9 @@ func Parse(cfg *beat.Config) (Config, error) {
 	err := cfg.Unpack(&config)
 	if err != nil {
 		return config, fmt.Errorf("unpack config error, %v", err)
+	}
+	if err = config.AdaptiveScan.Validate(); err != nil {
+		return config, err
 	}
 	logp.L.Infof("load config: %+v", config)
 

--- a/config/config.go
+++ b/config/config.go
@@ -68,10 +68,13 @@ type Config struct {
 
 // AdaptiveScanConfig 控制扫描周期自适应及其全局 CPU 预算。
 type AdaptiveScanConfig struct {
-	Enabled          bool          `config:"enabled"`
+	Enabled bool `config:"enabled"`
+	// MinScanFrequency 是动态缩短后的下限；若原配置周期更短，仍以原配置为准。
 	MinScanFrequency time.Duration `config:"min_scan_frequency"`
-	ScanCPUPercent   float64       `config:"scan_cpu_percent"`
-	ControlInterval  time.Duration `config:"control_interval"`
+	// ScanCPUPercent 是所有 input 聚合扫描耗时占单核时间的目标比例，不是单 input 配额。
+	ScanCPUPercent float64 `config:"scan_cpu_percent"`
+	// ControlInterval 是 governor 的采样与调节周期，与文件扫描周期相互独立。
+	ControlInterval time.Duration `config:"control_interval"`
 }
 
 func (c AdaptiveScanConfig) Validate() error {
@@ -137,6 +140,7 @@ func Parse(cfg *beat.Config) (Config, error) {
 		BufferTimeout: 1,
 		MaxCpuLimit:   -1,
 		CpuCheckTimes: 10,
+		// 默认关闭；其余值仅作为启用后的保守起步参数。
 		AdaptiveScan: AdaptiveScanConfig{
 			Enabled:          false,
 			MinScanFrequency: 500 * time.Millisecond,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -44,8 +44,8 @@ func TestParseAdaptiveScanDefaults(t *testing.T) {
 
 	cfg, err := Parse(raw)
 	assert.NoError(t, err)
-	assert.False(t, cfg.AdaptiveScan.Enabled)
-	assert.Equal(t, 500*time.Millisecond, cfg.AdaptiveScan.MinScanFrequency)
+	assert.True(t, cfg.AdaptiveScan.Enabled)
+	assert.Equal(t, time.Second, cfg.AdaptiveScan.MinScanFrequency)
 	assert.Equal(t, float64(5), cfg.AdaptiveScan.ScanCPUPercent)
 	assert.Equal(t, 3*time.Second, cfg.AdaptiveScan.ControlInterval)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,12 +23,111 @@
 package config
 
 import (
+	"math"
 	"os"
 	"testing"
+	"time"
 
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse/logp"
 	"github.com/elastic/beats/libbeat/common"
+	libbeatlogp "github.com/elastic/beats/libbeat/logp"
 	"github.com/stretchr/testify/assert"
 )
+
+func init() {
+	logp.SetLogger(libbeatlogp.L())
+}
+
+func TestParseAdaptiveScanDefaults(t *testing.T) {
+	raw, err := common.NewConfigFrom(map[string]interface{}{})
+	assert.NoError(t, err)
+
+	cfg, err := Parse(raw)
+	assert.NoError(t, err)
+	assert.False(t, cfg.AdaptiveScan.Enabled)
+	assert.Equal(t, 500*time.Millisecond, cfg.AdaptiveScan.MinScanFrequency)
+	assert.Equal(t, float64(5), cfg.AdaptiveScan.ScanCPUPercent)
+	assert.Equal(t, 3*time.Second, cfg.AdaptiveScan.ControlInterval)
+}
+
+func TestParseAdaptiveScanCustomConfig(t *testing.T) {
+	raw, err := common.NewConfigFrom(map[string]interface{}{
+		"adaptive_scan": map[string]interface{}{
+			"enabled":            true,
+			"min_scan_frequency": "750ms",
+			"scan_cpu_percent":   8.5,
+			"control_interval":   "5s",
+		},
+	})
+	assert.NoError(t, err)
+
+	cfg, err := Parse(raw)
+	assert.NoError(t, err)
+	assert.True(t, cfg.AdaptiveScan.Enabled)
+	assert.Equal(t, 750*time.Millisecond, cfg.AdaptiveScan.MinScanFrequency)
+	assert.Equal(t, 8.5, cfg.AdaptiveScan.ScanCPUPercent)
+	assert.Equal(t, 5*time.Second, cfg.AdaptiveScan.ControlInterval)
+}
+
+func TestParseAdaptiveScanRejectsInvalidEnabledConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		values map[string]interface{}
+	}{
+		{
+			name: "non-positive minimum interval",
+			values: map[string]interface{}{
+				"min_scan_frequency": "0s",
+			},
+		},
+		{
+			name: "non-positive cpu percent",
+			values: map[string]interface{}{
+				"scan_cpu_percent": 0,
+			},
+		},
+		{
+			name: "cpu percent above one core",
+			values: map[string]interface{}{
+				"scan_cpu_percent": 101,
+			},
+		},
+		{
+			name: "non-positive control interval",
+			values: map[string]interface{}{
+				"control_interval": "0s",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adaptive := map[string]interface{}{"enabled": true}
+			for key, value := range tt.values {
+				adaptive[key] = value
+			}
+			raw, err := common.NewConfigFrom(map[string]interface{}{
+				"adaptive_scan": adaptive,
+			})
+			assert.NoError(t, err)
+
+			_, err = Parse(raw)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestAdaptiveScanConfigRejectsNonFiniteCPUPercent(t *testing.T) {
+	for _, percent := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+		err := (AdaptiveScanConfig{
+			Enabled:          true,
+			MinScanFrequency: time.Second,
+			ScanCPUPercent:   percent,
+			ControlInterval:  time.Second,
+		}).Validate()
+		assert.Error(t, err)
+	}
+}
 
 func TestLoadConfig(t *testing.T) {
 	content := `

--- a/config/task.go
+++ b/config/task.go
@@ -155,8 +155,9 @@ func (c SenderConfig) GetExtMeta() map[string]interface{} {
 // TaskConfig 采集任务配置
 type TaskConfig struct {
 	ID     string
-	Type   string `config:"type"`
-	DataID int    `config:"dataid"`
+	Type   string   `config:"type"`
+	DataID int      `config:"dataid"`
+	Paths  []string `config:"paths"`
 
 	ProcessorConfig `config:",inline"`
 	FiltersConfig   `config:",inline"`

--- a/go.mod
+++ b/go.mod
@@ -116,6 +116,6 @@ require (
 
 replace (
 	github.com/Sirupsen/logrus v1.6.0 => github.com/sirupsen/logrus v1.9.3
-	github.com/elastic/beats v7.1.1+incompatible => github.com/TencentBlueking/beats v7.1.54-bk+incompatible
+	github.com/elastic/beats v7.1.1+incompatible => github.com/TencentBlueking/beats v7.1.55-bk+incompatible
 	github.com/sirupsen/logrus v1.8.1 => github.com/sirupsen/logrus v1.9.3
 )

--- a/go.mod
+++ b/go.mod
@@ -116,6 +116,6 @@ require (
 
 replace (
 	github.com/Sirupsen/logrus v1.6.0 => github.com/sirupsen/logrus v1.9.3
-	github.com/elastic/beats v7.1.1+incompatible => github.com/TencentBlueking/beats v7.1.53-bk+incompatible
+	github.com/elastic/beats v7.1.1+incompatible => github.com/TencentBlueking/beats v7.1.54-bk+incompatible
 	github.com/sirupsen/logrus v1.8.1 => github.com/sirupsen/logrus v1.9.3
 )

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse v1.9.1-alpha.1 h1:kJH1O
 github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse v1.9.1-alpha.1/go.mod h1:gDiD8QFEEugzdlgdm7MGPp1szzwgKca0FZkhmTZ67Y0=
 github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils v0.3.0 h1:M22V54nzKf4jReUWp9+rF0255nvlQP/B4zzuXIGyBlU=
 github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils v0.3.0/go.mod h1:ETap19QgROaVGv9E9MRtWMeOgx/gbhbtzcjk4cgadoM=
-github.com/TencentBlueking/beats v7.1.53-bk+incompatible h1:5uzFBednpBEEpL5yhrNA+AdzX3G/aLnSDyNLrtN7qPI=
-github.com/TencentBlueking/beats v7.1.53-bk+incompatible/go.mod h1:tJ6ZFzI1DAUQUUyvPBYVlmGBuH3QKGDK9mwN4LBg+Os=
+github.com/TencentBlueking/beats v7.1.54-bk+incompatible h1:jaFjB3K9G6JciwH8PEOimDR/IdvT5IN1qCnJaYQ1jdA=
+github.com/TencentBlueking/beats v7.1.54-bk+incompatible/go.mod h1:tJ6ZFzI1DAUQUUyvPBYVlmGBuH3QKGDK9mwN4LBg+Os=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse v1.9.1-alpha.1 h1:kJH1O
 github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse v1.9.1-alpha.1/go.mod h1:gDiD8QFEEugzdlgdm7MGPp1szzwgKca0FZkhmTZ67Y0=
 github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils v0.3.0 h1:M22V54nzKf4jReUWp9+rF0255nvlQP/B4zzuXIGyBlU=
 github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils v0.3.0/go.mod h1:ETap19QgROaVGv9E9MRtWMeOgx/gbhbtzcjk4cgadoM=
-github.com/TencentBlueking/beats v7.1.54-bk+incompatible h1:jaFjB3K9G6JciwH8PEOimDR/IdvT5IN1qCnJaYQ1jdA=
-github.com/TencentBlueking/beats v7.1.54-bk+incompatible/go.mod h1:tJ6ZFzI1DAUQUUyvPBYVlmGBuH3QKGDK9mwN4LBg+Os=
+github.com/TencentBlueking/beats v7.1.55-bk+incompatible h1:Px1ONx7nuLrGPPA8wdkDu7FE0hBiPo7pIFhIkFq5I24=
+github.com/TencentBlueking/beats v7.1.55-bk+incompatible/go.mod h1:tJ6ZFzI1DAUQUUyvPBYVlmGBuH3QKGDK9mwN4LBg+Os=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/task/formatter/v2_test.go
+++ b/task/formatter/v2_test.go
@@ -116,6 +116,7 @@ func TestV2FormatterMountReplace(t *testing.T) {
 			{"/test/sub/mount", "/mount"},
 		},
 		"remove_path_prefix": "/var/host",
+		"root_fs":            "/var/host",
 		"is_container_std":   true,
 	}
 	taskConfig, err := config.CreateTaskConfig(vars)
@@ -141,12 +142,12 @@ func TestV2FormatterMountReplace(t *testing.T) {
 
 	data := f.Format([]*util.Data{event})
 
-	assert.Equal(t, data["filename"], "/data/datahub/udp/backup/a/b/c.log")
+	assert.Equal(t, "/data/datahub/udp/backup/a/b/c.log", data["filename"])
 
 	event.SetState(file.State{Source: "/var/host/var/lib/kubelet/pods/ab7e4dcd-4c93-4f01-8ebd-fb7bcc293bd9/volumes/kubernetes.io~csi/pvc-38265a73-baa1-4249-879b-af4bbc30a7ba/mount/d/e/f.log"})
 
 	data = f.Format([]*util.Data{event})
 
-	assert.Equal(t, data["filename"], "/data/datahub/backup/deeper/d/e/f.log")
+	assert.Equal(t, "/data/datahub/backup/deeper/d/e/f.log", data["filename"])
 
 }

--- a/task/input/input.go
+++ b/task/input/input.go
@@ -83,6 +83,7 @@ func GetInput(
 		}
 		in.AddOutput(f.Node)
 		in.AddTaskNode(f.Node, taskNode)
+		// 共享 input 每接入一个 Task 都追加一份元数据，日志才能还原完整任务列表。
 		utils.RegisterAdaptiveScanInput(in.runner.AdaptiveScanID(), adaptiveScanMetadataFromTask(taskCfg))
 		return in, nil
 	}
@@ -117,6 +118,7 @@ func NewInput(
 	if err != nil {
 		return nil, err
 	}
+	// Runner 创建后才有进程内唯一 AdaptiveScanID，元数据必须以该实例 ID 注册。
 	utils.RegisterAdaptiveScanInput(in.runner.AdaptiveScanID(), adaptiveScanMetadataFromTask(taskCfg))
 
 	logp.L.Infof("add input(%s) to global inputMaps", in.ID)
@@ -220,6 +222,7 @@ func (in *Input) stop() {
 		runner := in.runner
 		go func() {
 			runner.Stop() // 防止卡主reload的流程，这里改为异步，不等待input结束
+			// 必须等待 Runner 完全停止后再清理，避免在途回调重新创建已删除的控制状态。
 			utils.UnregisterAdaptiveScanInput(runner.AdaptiveScanID())
 		}()
 	})

--- a/task/input/input.go
+++ b/task/input/input.go
@@ -83,6 +83,7 @@ func GetInput(
 		}
 		in.AddOutput(f.Node)
 		in.AddTaskNode(f.Node, taskNode)
+		utils.RegisterAdaptiveScanInput(in.runner.AdaptiveScanID(), adaptiveScanMetadataFromTask(taskCfg))
 		return in, nil
 	}
 
@@ -116,6 +117,7 @@ func NewInput(
 	if err != nil {
 		return nil, err
 	}
+	utils.RegisterAdaptiveScanInput(in.runner.AdaptiveScanID(), adaptiveScanMetadataFromTask(taskCfg))
 
 	logp.L.Infof("add input(%s) to global inputMaps", in.ID)
 	mtx.Lock()
@@ -212,8 +214,33 @@ func (in *Input) Run() {
 //  2. 当End的channel被主动关闭后
 func (in *Input) stop() {
 	in.stopOnce.Do(func() {
-		go in.runner.Stop() // 防止卡主reload的流程，这里改为异步，不等待input结束
+		if in.runner == nil {
+			return
+		}
+		runner := in.runner
+		go func() {
+			runner.Stop() // 防止卡主reload的流程，这里改为异步，不等待input结束
+			utils.UnregisterAdaptiveScanInput(runner.AdaptiveScanID())
+		}()
 	})
+}
+
+func adaptiveScanMetadataFromTask(taskConfig *config.TaskConfig) utils.AdaptiveScanInputMetadata {
+	return utils.AdaptiveScanInputMetadata{
+		InputID: taskConfig.InputID,
+		TaskID:  taskConfig.ID,
+		DataID:  taskConfig.DataID,
+		Paths:   append([]string(nil), taskConfig.Paths...),
+	}
+}
+
+// UnregisterAdaptiveScanTask 从当前 Runner 的诊断元数据中移除指定任务，
+// 同时保留共享该 Runner 的其他任务。
+func (in *Input) UnregisterAdaptiveScanTask(taskConfig *config.TaskConfig) {
+	if in.runner == nil || taskConfig == nil {
+		return
+	}
+	utils.UnregisterAdaptiveScanTask(in.runner.AdaptiveScanID(), adaptiveScanMetadataFromTask(taskConfig))
 }
 
 // Reload : Input不做reload处理，配置如果有变化，直接删除新建

--- a/task/input/input_test.go
+++ b/task/input/input_test.go
@@ -1,0 +1,31 @@
+// Tencent is pleased to support the open source community by making bkunifylogbeat 蓝鲸日志采集器 available.
+//
+// Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License.
+
+package input
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TencentBlueKing/bkunifylogbeat/config"
+	"github.com/TencentBlueKing/bkunifylogbeat/utils"
+)
+
+func TestAdaptiveScanMetadataFromTask(t *testing.T) {
+	taskConfig := &config.TaskConfig{
+		ID:      "task-a",
+		InputID: "input-a",
+		DataID:  1001,
+		Paths:   []string{"/var/log/app.log"},
+	}
+
+	assert.Equal(t, utils.AdaptiveScanInputMetadata{
+		InputID: "input-a",
+		TaskID:  "task-a",
+		DataID:  1001,
+		Paths:   []string{"/var/log/app.log"},
+	}, adaptiveScanMetadataFromTask(taskConfig))
+}

--- a/task/task.go
+++ b/task/task.go
@@ -119,6 +119,7 @@ func (task *Task) Run() {
 // Stop 负责停止采集任务实例，在Filebeat采集插件停止后退出
 func (task *Task) Stop() error {
 	logp.L.Infof("task(%s) is Stop", task.ID)
+	// Task 退出只移除自己的诊断元数据；底层共享 input 可能仍在服务其他 Task。
 	task.input.UnregisterAdaptiveScanTask(task.Config)
 	task.ParentNode.RemoveOutput(task.Node)
 	task.ParentNode.RemoveTaskNode(task.Node, task.TaskNode)

--- a/task/task.go
+++ b/task/task.go
@@ -119,6 +119,7 @@ func (task *Task) Run() {
 // Stop 负责停止采集任务实例，在Filebeat采集插件停止后退出
 func (task *Task) Stop() error {
 	logp.L.Infof("task(%s) is Stop", task.ID)
+	task.input.UnregisterAdaptiveScanTask(task.Config)
 	task.ParentNode.RemoveOutput(task.Node)
 	task.ParentNode.RemoveTaskNode(task.Node, task.TaskNode)
 

--- a/utils/adaptive_scan.go
+++ b/utils/adaptive_scan.go
@@ -1,0 +1,603 @@
+// Tencent is pleased to support the open source community by making bkunifylogbeat 蓝鲸日志采集器 available.
+//
+// Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License.
+
+package utils
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse/logp"
+)
+
+const (
+	adaptiveScanEWMAAlpha        = 0.5
+	adaptiveScanDeadbandRatio    = 0.15
+	adaptiveScanMaxStepRatio     = 2.0
+	adaptiveScanMaxMultiplier    = 64.0
+	adaptiveScanInitialMultiple  = 1.0
+	adaptiveScanLogMinInterval   = time.Minute
+	adaptiveScanSnapshotInterval = 5 * time.Minute
+	adaptiveScanSnapshotTopK     = 5
+)
+
+// AdaptiveScanSettings 控制单 input 周期计算和全局扫描 CPU 预算。
+// ScanCPUPercent 表示扫描耗时占单核时间的百分比。
+type AdaptiveScanSettings struct {
+	MinScanFrequency time.Duration
+	ScanCPUPercent   float64
+	ControlInterval  time.Duration
+}
+
+type adaptiveScanInputState struct {
+	ewmaScanNanos      float64
+	lastLoggedInterval time.Duration
+	lastLogAt          time.Time
+	baseInterval       time.Duration
+	requestedInterval  time.Duration
+	effectiveInterval  time.Duration
+	lastScanDuration   time.Duration
+}
+
+// AdaptiveScanIntervalLog 表示一条经过限频的扫描周期变更记录。
+type AdaptiveScanIntervalLog struct {
+	RunnerID          uint64
+	InputID           string
+	TaskIDs           []string
+	DataIDs           []int
+	Paths             []string
+	BaseInterval      time.Duration
+	RequestedInterval time.Duration
+	EffectiveInterval time.Duration
+	Multiplier        float64
+	ScanDuration      time.Duration
+}
+
+// AdaptiveScanIntervalDistribution 是周期快照中固定桶数的扫描周期分布。
+type AdaptiveScanIntervalDistribution struct {
+	AtMinimum     int
+	UpTo1Second   int
+	UpTo2Seconds  int
+	UpTo5Seconds  int
+	Above5Seconds int
+	AtBase        int
+}
+
+// AdaptiveScanSnapshotInput 表示生效周期与基础周期比值最大的 input 之一。
+type AdaptiveScanSnapshotInput struct {
+	RunnerID          uint64
+	InputID           string
+	TaskIDs           []string
+	DataIDs           []int
+	BaseInterval      time.Duration
+	RequestedInterval time.Duration
+	EffectiveInterval time.Duration
+	ScanDuration      time.Duration
+}
+
+// AdaptiveScanSnapshot 表示一条固定大小的控制器聚合快照。
+type AdaptiveScanSnapshot struct {
+	Inputs        int
+	Shortened     int
+	Multiplier    float64
+	ScanDuty      float64
+	TargetDuty    float64
+	Intervals     AdaptiveScanIntervalDistribution
+	SlowestInputs []AdaptiveScanSnapshotInput
+}
+
+// AdaptiveScanController 计算每个 input 的扫描周期，并维护限制聚合扫描开销的全局乘数。
+type AdaptiveScanController struct {
+	minScanFrequency time.Duration
+	controlInterval  time.Duration
+	targetDuty       float64
+
+	mu     sync.Mutex
+	inputs map[uint64]*adaptiveScanInputState
+
+	totalScanNanos atomic.Int64
+	multiplierBits atomic.Uint64
+	lastDutyBits   atomic.Uint64
+
+	sampleMu        sync.Mutex
+	lastSampleAt    time.Time
+	lastSampleTotal int64
+	smoothedDuty    float64
+	hasSmoothedDuty bool
+
+	lifecycleMu sync.Mutex
+	running     bool
+	done        chan struct{}
+	wg          sync.WaitGroup
+
+	now               func() time.Time
+	logIntervalChange func(AdaptiveScanIntervalLog)
+	snapshotInterval  time.Duration
+	logSnapshot       func(AdaptiveScanSnapshot)
+	logInputSnapshots func([]AdaptiveScanIntervalLog)
+}
+
+// NewAdaptiveScanController 创建自适应扫描控制器。
+func NewAdaptiveScanController(settings AdaptiveScanSettings) (*AdaptiveScanController, error) {
+	if settings.MinScanFrequency <= 0 {
+		return nil, fmt.Errorf("min scan frequency must be greater than 0")
+	}
+	if settings.ScanCPUPercent <= 0 || settings.ScanCPUPercent > 100 ||
+		math.IsNaN(settings.ScanCPUPercent) || math.IsInf(settings.ScanCPUPercent, 0) {
+		return nil, fmt.Errorf("scan CPU percent must be greater than 0 and no more than 100")
+	}
+	if settings.ControlInterval <= 0 {
+		return nil, fmt.Errorf("control interval must be greater than 0")
+	}
+
+	controller := &AdaptiveScanController{
+		minScanFrequency:  settings.MinScanFrequency,
+		controlInterval:   settings.ControlInterval,
+		targetDuty:        settings.ScanCPUPercent / 100,
+		inputs:            make(map[uint64]*adaptiveScanInputState),
+		now:               time.Now,
+		logIntervalChange: logAdaptiveScanIntervalChange,
+		snapshotInterval:  adaptiveScanSnapshotInterval,
+		logSnapshot:       logAdaptiveScanSnapshot,
+		logInputSnapshots: logAdaptiveScanInputSnapshots,
+	}
+	controller.setMultiplier(adaptiveScanInitialMultiple)
+	return controller, nil
+}
+
+// NextInterval 记录最新扫描开销并计算候选周期。
+// 配置周期始终是上限，因此开启自适应后不会比原配置扫描得更慢。
+func (c *AdaptiveScanController) NextInterval(inputID uint64, base, scanDuration time.Duration) time.Duration {
+	if base <= 0 || scanDuration <= 0 {
+		return base
+	}
+
+	c.totalScanNanos.Add(int64(scanDuration))
+
+	c.mu.Lock()
+	state, ok := c.inputs[inputID]
+	if !ok {
+		state = &adaptiveScanInputState{ewmaScanNanos: float64(scanDuration)}
+		c.inputs[inputID] = state
+	} else {
+		state.ewmaScanNanos = adaptiveScanEWMAAlpha*float64(scanDuration) +
+			(1-adaptiveScanEWMAAlpha)*state.ewmaScanNanos
+	}
+	ewmaScanNanos := state.ewmaScanNanos
+	c.mu.Unlock()
+
+	minimum := c.minScanFrequency
+	if base < minimum {
+		minimum = base
+	}
+
+	localNanos := ewmaScanNanos / c.targetDuty
+	local := base
+	if localNanos < float64(base) {
+		local = clampDuration(time.Duration(localNanos), minimum, base)
+	}
+
+	effective := float64(local) * c.Multiplier()
+	var interval time.Duration
+	if effective >= float64(base) {
+		interval = base
+	} else {
+		interval = clampDuration(time.Duration(effective), minimum, base)
+	}
+
+	return interval
+}
+
+// ObserveApplied 接收 Beats 归一化后的最终扫描周期。
+// 日志与快照只使用 applied，确保观测值和 Runner 实际等待时间一致。
+func (c *AdaptiveScanController) ObserveApplied(
+	inputID uint64,
+	base, requested, applied, scanDuration time.Duration,
+) {
+	c.mu.Lock()
+	state := c.inputs[inputID]
+	if state == nil {
+		c.mu.Unlock()
+		return
+	}
+	state.baseInterval = base
+	state.requestedInterval = requested
+	state.effectiveInterval = applied
+	state.lastScanDuration = scanDuration
+	c.mu.Unlock()
+
+	c.maybeLogIntervalChange(inputID, base, requested, applied, scanDuration)
+}
+
+// TotalScanDuration 返回累计实测扫描耗时。
+func (c *AdaptiveScanController) TotalScanDuration() time.Duration {
+	return time.Duration(c.totalScanNanos.Load())
+}
+
+func (c *AdaptiveScanController) removeInput(inputID uint64) {
+	c.mu.Lock()
+	delete(c.inputs, inputID)
+	c.mu.Unlock()
+}
+
+// Multiplier 返回当前全局扫描周期乘数。
+func (c *AdaptiveScanController) Multiplier() float64 {
+	return math.Float64frombits(c.multiplierBits.Load())
+}
+
+// Start 启动聚合扫描占空比的周期采样。
+func (c *AdaptiveScanController) Start() {
+	c.lifecycleMu.Lock()
+	defer c.lifecycleMu.Unlock()
+	if c.running {
+		return
+	}
+
+	c.sampleMu.Lock()
+	c.lastSampleAt = time.Now()
+	c.lastSampleTotal = c.totalScanNanos.Load()
+	c.smoothedDuty = 0
+	c.hasSmoothedDuty = false
+	c.lastDutyBits.Store(math.Float64bits(0))
+	c.sampleMu.Unlock()
+
+	c.done = make(chan struct{})
+	c.running = true
+	c.wg.Add(1)
+	go c.runGovernor(c.done)
+}
+
+// Stop 停止聚合扫描占空比的周期采样。
+func (c *AdaptiveScanController) Stop() {
+	c.lifecycleMu.Lock()
+	defer c.lifecycleMu.Unlock()
+	if !c.running {
+		return
+	}
+
+	close(c.done)
+	c.running = false
+	c.wg.Wait()
+}
+
+func (c *AdaptiveScanController) runGovernor(done <-chan struct{}) {
+	defer c.wg.Done()
+	ticker := time.NewTicker(c.controlInterval)
+	defer ticker.Stop()
+	snapshotTicker := time.NewTicker(c.snapshotInterval)
+	defer snapshotTicker.Stop()
+
+	for {
+		select {
+		case <-done:
+			return
+		case now := <-ticker.C:
+			c.observeSample(now, c.totalScanNanos.Load())
+		case <-snapshotTicker.C:
+			c.logSnapshot(c.snapshot())
+			c.logInputSnapshots(c.inputSnapshots())
+		}
+	}
+}
+
+func (c *AdaptiveScanController) observeSample(now time.Time, totalNanos int64) {
+	c.sampleMu.Lock()
+	if c.lastSampleAt.IsZero() || totalNanos < c.lastSampleTotal {
+		c.lastSampleAt = now
+		c.lastSampleTotal = totalNanos
+		c.sampleMu.Unlock()
+		return
+	}
+
+	elapsed := now.Sub(c.lastSampleAt)
+	deltaNanos := totalNanos - c.lastSampleTotal
+	c.lastSampleAt = now
+	c.lastSampleTotal = totalNanos
+
+	if elapsed <= 0 {
+		c.sampleMu.Unlock()
+		return
+	}
+	duty := float64(deltaNanos) / float64(elapsed)
+	if c.hasSmoothedDuty {
+		c.smoothedDuty = adaptiveScanEWMAAlpha*duty +
+			(1-adaptiveScanEWMAAlpha)*c.smoothedDuty
+	} else {
+		c.smoothedDuty = duty
+		c.hasSmoothedDuty = true
+	}
+	smoothedDuty := c.smoothedDuty
+	c.sampleMu.Unlock()
+
+	c.lastDutyBits.Store(math.Float64bits(smoothedDuty))
+	c.updateMultiplier(smoothedDuty)
+}
+
+func (c *AdaptiveScanController) setMultiplier(value float64) {
+	c.multiplierBits.Store(math.Float64bits(value))
+}
+
+func (c *AdaptiveScanController) updateMultiplier(duty float64) {
+	if duty < 0 || math.IsNaN(duty) || math.IsInf(duty, 0) {
+		return
+	}
+
+	current := c.Multiplier()
+	if duty >= c.targetDuty*(1-adaptiveScanDeadbandRatio) &&
+		duty <= c.targetDuty*(1+adaptiveScanDeadbandRatio) {
+		return
+	}
+
+	target := current * duty / c.targetDuty
+	target = clampFloat(target, 1, adaptiveScanMaxMultiplier)
+	target = clampFloat(target, current/adaptiveScanMaxStepRatio, current*adaptiveScanMaxStepRatio)
+
+	next := adaptiveScanEWMAAlpha*target + (1-adaptiveScanEWMAAlpha)*current
+	c.setMultiplier(clampFloat(next, 1, adaptiveScanMaxMultiplier))
+}
+
+func (c *AdaptiveScanController) maybeLogIntervalChange(
+	runnerID uint64,
+	base, requested, effective, scanDuration time.Duration,
+) {
+	metadata, ok := adaptiveScanInputMetadata(runnerID)
+	if !ok {
+		return
+	}
+
+	now := c.now()
+	c.mu.Lock()
+	state := c.inputs[runnerID]
+	if state == nil {
+		c.mu.Unlock()
+		return
+	}
+	shouldLog := (state.lastLoggedInterval == 0 && (effective < base || requested != effective)) ||
+		(state.lastLoggedInterval != 0 &&
+			now.Sub(state.lastLogAt) >= adaptiveScanLogMinInterval &&
+			isMeaningfulAdaptiveScanIntervalChange(state.lastLoggedInterval, effective, base))
+	if shouldLog {
+		state.lastLoggedInterval = effective
+		state.lastLogAt = now
+	}
+	c.mu.Unlock()
+	if !shouldLog {
+		return
+	}
+
+	c.logIntervalChange(AdaptiveScanIntervalLog{
+		RunnerID:          runnerID,
+		InputID:           metadata.InputID,
+		TaskIDs:           metadata.TaskIDs,
+		DataIDs:           metadata.DataIDs,
+		Paths:             metadata.Paths,
+		BaseInterval:      base,
+		RequestedInterval: requested,
+		EffectiveInterval: effective,
+		Multiplier:        c.Multiplier(),
+		ScanDuration:      scanDuration,
+	})
+}
+
+func (c *AdaptiveScanController) snapshot() AdaptiveScanSnapshot {
+	type candidate struct {
+		runnerID uint64
+		score    float64
+		state    adaptiveScanInputState
+	}
+
+	snapshot := AdaptiveScanSnapshot{
+		Multiplier: c.Multiplier(),
+		ScanDuty:   math.Float64frombits(c.lastDutyBits.Load()),
+		TargetDuty: c.targetDuty,
+	}
+	var candidates []candidate
+
+	c.mu.Lock()
+	snapshot.Inputs = len(c.inputs)
+	for runnerID, state := range c.inputs {
+		if state.baseInterval <= 0 || state.effectiveInterval <= 0 {
+			continue
+		}
+		if state.effectiveInterval < state.baseInterval {
+			snapshot.Shortened++
+		}
+
+		minimum := c.minScanFrequency
+		if state.baseInterval < minimum {
+			minimum = state.baseInterval
+		}
+		switch {
+		case state.effectiveInterval >= state.baseInterval:
+			snapshot.Intervals.AtBase++
+		case state.effectiveInterval <= minimum:
+			snapshot.Intervals.AtMinimum++
+		case state.effectiveInterval <= time.Second:
+			snapshot.Intervals.UpTo1Second++
+		case state.effectiveInterval <= 2*time.Second:
+			snapshot.Intervals.UpTo2Seconds++
+		case state.effectiveInterval <= 5*time.Second:
+			snapshot.Intervals.UpTo5Seconds++
+		default:
+			snapshot.Intervals.Above5Seconds++
+		}
+
+		candidates = append(candidates, candidate{
+			runnerID: runnerID,
+			score:    float64(state.effectiveInterval) / float64(state.baseInterval),
+			state:    *state,
+		})
+	}
+	c.mu.Unlock()
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].score == candidates[j].score {
+			return candidates[i].runnerID < candidates[j].runnerID
+		}
+		return candidates[i].score > candidates[j].score
+	})
+	if len(candidates) > adaptiveScanSnapshotTopK {
+		candidates = candidates[:adaptiveScanSnapshotTopK]
+	}
+
+	for _, item := range candidates {
+		record := AdaptiveScanSnapshotInput{
+			RunnerID:          item.runnerID,
+			BaseInterval:      item.state.baseInterval,
+			RequestedInterval: item.state.requestedInterval,
+			EffectiveInterval: item.state.effectiveInterval,
+			ScanDuration:      item.state.lastScanDuration,
+		}
+		if metadata, ok := adaptiveScanInputMetadata(item.runnerID); ok {
+			record.InputID = metadata.InputID
+			record.TaskIDs = metadata.TaskIDs
+			record.DataIDs = metadata.DataIDs
+		}
+		snapshot.SlowestInputs = append(snapshot.SlowestInputs, record)
+	}
+	return snapshot
+}
+
+func (c *AdaptiveScanController) inputSnapshots() []AdaptiveScanIntervalLog {
+	type stateSnapshot struct {
+		runnerID uint64
+		state    adaptiveScanInputState
+	}
+
+	c.mu.Lock()
+	states := make([]stateSnapshot, 0, len(c.inputs))
+	for runnerID, state := range c.inputs {
+		states = append(states, stateSnapshot{runnerID: runnerID, state: *state})
+	}
+	c.mu.Unlock()
+
+	sort.Slice(states, func(i, j int) bool {
+		return states[i].runnerID < states[j].runnerID
+	})
+	records := make([]AdaptiveScanIntervalLog, 0, len(states))
+	for _, item := range states {
+		record := AdaptiveScanIntervalLog{
+			RunnerID:          item.runnerID,
+			BaseInterval:      item.state.baseInterval,
+			RequestedInterval: item.state.requestedInterval,
+			EffectiveInterval: item.state.effectiveInterval,
+			Multiplier:        c.Multiplier(),
+			ScanDuration:      item.state.lastScanDuration,
+		}
+		if metadata, ok := adaptiveScanInputMetadata(item.runnerID); ok {
+			record.InputID = metadata.InputID
+			record.TaskIDs = metadata.TaskIDs
+			record.DataIDs = metadata.DataIDs
+			record.Paths = metadata.Paths
+		}
+		records = append(records, record)
+	}
+	return records
+}
+
+func isMeaningfulAdaptiveScanIntervalChange(previous, current, base time.Duration) bool {
+	if previous <= 0 || current <= 0 {
+		return true
+	}
+	larger, smaller := previous, current
+	if current > previous {
+		larger, smaller = current, previous
+	}
+	if larger >= 2*smaller {
+		return true
+	}
+	return adaptiveScanIntervalBucket(previous, base) != adaptiveScanIntervalBucket(current, base)
+}
+
+func adaptiveScanIntervalBucket(interval, base time.Duration) int {
+	switch {
+	case interval >= base:
+		return 5
+	case interval <= 500*time.Millisecond:
+		return 0
+	case interval <= time.Second:
+		return 1
+	case interval <= 2*time.Second:
+		return 2
+	case interval <= 5*time.Second:
+		return 3
+	default:
+		return 4
+	}
+}
+
+func logAdaptiveScanIntervalChange(record AdaptiveScanIntervalLog) {
+	logp.L.Infof(
+		"adaptive scan interval changed: runner_id=%d input_id=%s task_ids=%v data_ids=%v paths=%v "+
+			"base=%s requested_interval=%s effective_interval=%s multiplier=%.3f scan_duration=%s",
+		record.RunnerID,
+		record.InputID,
+		record.TaskIDs,
+		record.DataIDs,
+		record.Paths,
+		record.BaseInterval,
+		record.RequestedInterval,
+		record.EffectiveInterval,
+		record.Multiplier,
+		record.ScanDuration,
+	)
+}
+
+func logAdaptiveScanSnapshot(snapshot AdaptiveScanSnapshot) {
+	logp.L.Infof(
+		"adaptive scan snapshot: inputs=%d shortened=%d multiplier=%.3f scan_duty=%.4f "+
+			"target_duty=%.4f intervals=%+v slowest_inputs=%+v",
+		snapshot.Inputs,
+		snapshot.Shortened,
+		snapshot.Multiplier,
+		snapshot.ScanDuty,
+		snapshot.TargetDuty,
+		snapshot.Intervals,
+		snapshot.SlowestInputs,
+	)
+}
+
+func logAdaptiveScanInputSnapshots(records []AdaptiveScanIntervalLog) {
+	for _, record := range records {
+		logp.L.Debugf(
+			"adaptive scan input snapshot: runner_id=%d input_id=%s task_ids=%v data_ids=%v paths=%v "+
+				"base=%s requested_interval=%s effective_interval=%s multiplier=%.3f scan_duration=%s",
+			record.RunnerID,
+			record.InputID,
+			record.TaskIDs,
+			record.DataIDs,
+			record.Paths,
+			record.BaseInterval,
+			record.RequestedInterval,
+			record.EffectiveInterval,
+			record.Multiplier,
+			record.ScanDuration,
+		)
+	}
+}
+
+func clampDuration(value, minimum, maximum time.Duration) time.Duration {
+	if value < minimum {
+		return minimum
+	}
+	if value > maximum {
+		return maximum
+	}
+	return value
+}
+
+func clampFloat(value, minimum, maximum float64) float64 {
+	if value < minimum {
+		return minimum
+	}
+	if value > maximum {
+		return maximum
+	}
+	return value
+}

--- a/utils/adaptive_scan.go
+++ b/utils/adaptive_scan.go
@@ -17,14 +17,19 @@ import (
 )
 
 const (
-	// 同一个平滑系数同时用于单 input 扫描耗时和全局占空比，避免瞬时抖动直接改变周期。
+	// 单 input 扫描耗时 EWMA 参与控制；聚合占空比 EWMA 仅用于诊断快照。
 	adaptiveScanEWMAAlpha = 0.5
 	// 占空比落在目标值上下 15% 时不调整，防止 multiplier 在目标附近来回振荡。
 	adaptiveScanDeadbandRatio = 0.15
-	// 每轮控制将 multiplier 限制在当前值的 1/2 到 2 倍之间，并限制其最终上限。
-	adaptiveScanMaxStepRatio    = 2.0
-	adaptiveScanMaxMultiplier   = 64.0
-	adaptiveScanInitialMultiple = 1.0
+	// 超预算越严重，升档步长越大；恢复时保持保守，避免负载抖动导致周期骤降。
+	adaptiveScanNormalGrowthRatio    = 2.0
+	adaptiveScanModerateGrowthRatio  = 4.0
+	adaptiveScanEmergencyGrowthRatio = 8.0
+	adaptiveScanModerateDutyRatio    = 2.0
+	adaptiveScanEmergencyDutyRatio   = 8.0
+	adaptiveScanRecoveryRatio        = 0.75
+	adaptiveScanSearchIterations     = 60
+	adaptiveScanInitialMultiple      = 1.0
 	// 变更日志按 input 限频，聚合快照则提供固定周期的全局视图。
 	adaptiveScanLogMinInterval   = time.Minute
 	adaptiveScanSnapshotInterval = 5 * time.Minute
@@ -44,6 +49,7 @@ type adaptiveScanInputState struct {
 	lastLoggedInterval time.Duration
 	lastLogAt          time.Time
 	baseInterval       time.Duration
+	localInterval      time.Duration
 	requestedInterval  time.Duration
 	effectiveInterval  time.Duration
 	lastScanDuration   time.Duration
@@ -87,13 +93,17 @@ type AdaptiveScanSnapshotInput struct {
 
 // AdaptiveScanSnapshot 表示一条固定大小的控制器聚合快照。
 type AdaptiveScanSnapshot struct {
-	Inputs        int
-	Shortened     int
-	Multiplier    float64
-	ScanDuty      float64
-	TargetDuty    float64
-	Intervals     AdaptiveScanIntervalDistribution
-	SlowestInputs []AdaptiveScanSnapshotInput
+	Inputs     int
+	Shortened  int
+	Multiplier float64
+	ScanDuty   float64
+	TargetDuty float64
+	// MinimumPossibleDuty 是所有活跃 input 都退回基础周期后的最低聚合扫描占空比。
+	MinimumPossibleDuty float64
+	// BudgetSaturated 表示基础周期上限使目标预算无法满足。
+	BudgetSaturated bool
+	Intervals       AdaptiveScanIntervalDistribution
+	SlowestInputs   []AdaptiveScanSnapshotInput
 }
 
 // AdaptiveScanController 计算每个 input 的扫描周期，并维护限制聚合扫描开销的全局乘数。
@@ -108,9 +118,11 @@ type AdaptiveScanController struct {
 
 	// 热路径与 governor 通过原子值交换累计耗时、全局 multiplier 和最近占空比，
 	// 避免每个 Runner 在计算周期时争用 governor 的采样锁。
-	totalScanNanos atomic.Int64
-	multiplierBits atomic.Uint64
-	lastDutyBits   atomic.Uint64
+	totalScanNanos  atomic.Int64
+	multiplierBits  atomic.Uint64
+	lastDutyBits    atomic.Uint64
+	minimumDutyBits atomic.Uint64
+	budgetSaturated atomic.Bool
 
 	// sampleMu 保护相邻采样点及占空比 EWMA，仅由 governor 周期更新。
 	sampleMu        sync.Mutex
@@ -180,8 +192,6 @@ func (c *AdaptiveScanController) NextInterval(inputID uint64, base, scanDuration
 			(1-adaptiveScanEWMAAlpha)*state.ewmaScanNanos
 	}
 	ewmaScanNanos := state.ewmaScanNanos
-	c.mu.Unlock()
-
 	minimum := c.minScanFrequency
 	if base < minimum {
 		minimum = base
@@ -194,6 +204,11 @@ func (c *AdaptiveScanController) NextInterval(inputID uint64, base, scanDuration
 	if localNanos < float64(base) {
 		local = clampDuration(time.Duration(localNanos), minimum, base)
 	}
+	// governor 使用各 input 的稳态成本模型求解全局 multiplier；
+	// base/local 决定该 input 退回原配置周期前仍有多少调节空间。
+	state.baseInterval = base
+	state.localInterval = local
+	c.mu.Unlock()
 
 	// 第二层全局控制：所有 input 的局部周期统一乘以 governor 的 multiplier。
 	// 最终仍限制在 [minimum, base]，不会突破最小周期，也不会比原配置扫描得更慢。
@@ -260,6 +275,8 @@ func (c *AdaptiveScanController) Start() {
 	c.smoothedDuty = 0
 	c.hasSmoothedDuty = false
 	c.lastDutyBits.Store(math.Float64bits(0))
+	c.minimumDutyBits.Store(math.Float64bits(0))
+	c.budgetSaturated.Store(false)
 	c.sampleMu.Unlock()
 
 	c.done = make(chan struct{})
@@ -335,33 +352,138 @@ func (c *AdaptiveScanController) observeSample(now time.Time, totalNanos int64) 
 	c.sampleMu.Unlock()
 
 	c.lastDutyBits.Store(math.Float64bits(smoothedDuty))
-	c.updateMultiplier(smoothedDuty)
+	c.updateMultiplier()
 }
 
 func (c *AdaptiveScanController) setMultiplier(value float64) {
 	c.multiplierBits.Store(math.Float64bits(value))
 }
 
-func (c *AdaptiveScanController) updateMultiplier(duty float64) {
-	if duty < 0 || math.IsNaN(duty) || math.IsInf(duty, 0) {
-		return
+type adaptiveScanControlCost struct {
+	scanNanos  float64
+	localNanos float64
+	baseNanos  float64
+}
+
+type adaptiveScanControlModel struct {
+	inputs            int
+	maxMultiplier     float64
+	currentDuty       float64
+	minimumDuty       float64
+	desiredMultiplier float64
+}
+
+// controlModel 根据各 input 的扫描耗时 EWMA 和周期边界估算稳态聚合占空比。
+// 相比直接使用短采样窗口，模型不会在扫描周期大于 controlInterval 时因空窗口和突发窗口振荡。
+func (c *AdaptiveScanController) controlModel(current float64) adaptiveScanControlModel {
+	c.mu.Lock()
+	costs := make([]adaptiveScanControlCost, 0, len(c.inputs))
+	for _, state := range c.inputs {
+		if state.ewmaScanNanos <= 0 || state.localInterval <= 0 || state.baseInterval <= 0 {
+			continue
+		}
+		costs = append(costs, adaptiveScanControlCost{
+			scanNanos:  state.ewmaScanNanos,
+			localNanos: float64(state.localInterval),
+			baseNanos:  float64(state.baseInterval),
+		})
+	}
+	c.mu.Unlock()
+
+	model := adaptiveScanControlModel{
+		inputs:            len(costs),
+		maxMultiplier:     1,
+		desiredMultiplier: 1,
+	}
+	if len(costs) == 0 {
+		return model
 	}
 
+	for _, cost := range costs {
+		ratio := cost.baseNanos / cost.localNanos
+		if ratio > model.maxMultiplier {
+			model.maxMultiplier = ratio
+		}
+	}
+
+	dutyAt := func(multiplier float64) float64 {
+		var duty float64
+		for _, cost := range costs {
+			interval := cost.localNanos * multiplier
+			if interval > cost.baseNanos {
+				interval = cost.baseNanos
+			}
+			duty += cost.scanNanos / interval
+		}
+		return duty
+	}
+
+	current = clampFloat(current, 1, model.maxMultiplier)
+	model.currentDuty = dutyAt(current)
+	model.minimumDuty = dutyAt(model.maxMultiplier)
+	if dutyAt(1) <= c.targetDuty {
+		return model
+	}
+	if model.minimumDuty > c.targetDuty {
+		model.desiredMultiplier = model.maxMultiplier
+		return model
+	}
+
+	// dutyAt 随 multiplier 单调不增；二分得到满足预算的最小 multiplier，
+	// 避免固定上限阻断本可满足的配置，也避免超出所有 input 的实际调节空间。
+	low, high := 1.0, model.maxMultiplier
+	for range adaptiveScanSearchIterations {
+		middle := (low + high) / 2
+		if dutyAt(middle) > c.targetDuty {
+			low = middle
+		} else {
+			high = middle
+		}
+	}
+	model.desiredMultiplier = high
+	return model
+}
+
+func (c *AdaptiveScanController) updateMultiplier() {
 	current := c.Multiplier()
-	// 目标附近保留 15% 死区，避免扫描耗时的小幅波动导致周期频繁变化。
-	if duty >= c.targetDuty*(1-adaptiveScanDeadbandRatio) &&
-		duty <= c.targetDuty*(1+adaptiveScanDeadbandRatio) {
+	model := c.controlModel(current)
+	c.minimumDutyBits.Store(math.Float64bits(model.minimumDuty))
+	c.budgetSaturated.Store(model.inputs > 0 && model.minimumDuty > c.targetDuty)
+	if model.inputs == 0 {
+		c.setMultiplier(adaptiveScanInitialMultiple)
 		return
 	}
 
-	// 按 duty/target 的比例反推新 multiplier，再限制单次最大步长并做一次 EWMA。
-	// 这样既能在超预算时及时降频，也不会因单个异常采样突然跳到极端值。
-	target := current * duty / c.targetDuty
-	target = clampFloat(target, 1, adaptiveScanMaxMultiplier)
-	target = clampFloat(target, current/adaptiveScanMaxStepRatio, current*adaptiveScanMaxStepRatio)
+	current = clampFloat(current, 1, model.maxMultiplier)
+	// input 删除或局部周期变化可能降低动态上限，应立即收回已经无效的 multiplier。
+	if current != c.Multiplier() {
+		c.setMultiplier(current)
+	}
 
-	next := adaptiveScanEWMAAlpha*target + (1-adaptiveScanEWMAAlpha)*current
-	c.setMultiplier(clampFloat(next, 1, adaptiveScanMaxMultiplier))
+	// 目标附近保留 15% 死区，避免扫描耗时的小幅波动导致周期频繁变化。
+	if model.currentDuty >= c.targetDuty*(1-adaptiveScanDeadbandRatio) &&
+		model.currentDuty <= c.targetDuty*(1+adaptiveScanDeadbandRatio) {
+		return
+	}
+
+	var next float64
+	if model.currentDuty > c.targetDuty {
+		// 严重超预算时按 8 倍、4 倍、2 倍分级快速升档，但绝不越过模型求得的目标。
+		dutyRatio := model.currentDuty / c.targetDuty
+		growthRatio := adaptiveScanNormalGrowthRatio
+		switch {
+		case dutyRatio >= adaptiveScanEmergencyDutyRatio:
+			growthRatio = adaptiveScanEmergencyGrowthRatio
+		case dutyRatio >= adaptiveScanModerateDutyRatio:
+			growthRatio = adaptiveScanModerateGrowthRatio
+		}
+		next = math.Min(model.desiredMultiplier, current*growthRatio)
+	} else {
+		// 预算有余量时每轮最多回收 25%，保留原控制器的保守恢复特性。
+		next = math.Max(model.desiredMultiplier, current*adaptiveScanRecoveryRatio)
+	}
+
+	c.setMultiplier(clampFloat(next, 1, model.maxMultiplier))
 }
 
 func (c *AdaptiveScanController) maybeLogIntervalChange(
@@ -417,9 +539,11 @@ func (c *AdaptiveScanController) snapshot() AdaptiveScanSnapshot {
 	}
 
 	snapshot := AdaptiveScanSnapshot{
-		Multiplier: c.Multiplier(),
-		ScanDuty:   math.Float64frombits(c.lastDutyBits.Load()),
-		TargetDuty: c.targetDuty,
+		Multiplier:          c.Multiplier(),
+		ScanDuty:            math.Float64frombits(c.lastDutyBits.Load()),
+		TargetDuty:          c.targetDuty,
+		MinimumPossibleDuty: math.Float64frombits(c.minimumDutyBits.Load()),
+		BudgetSaturated:     c.budgetSaturated.Load(),
 	}
 	var candidates []candidate
 
@@ -576,12 +700,15 @@ func logAdaptiveScanIntervalChange(record AdaptiveScanIntervalLog) {
 func logAdaptiveScanSnapshot(snapshot AdaptiveScanSnapshot) {
 	logp.L.Infof(
 		"adaptive scan snapshot: inputs=%d shortened=%d multiplier=%.3f scan_duty=%.4f "+
-			"target_duty=%.4f intervals=%+v slowest_inputs=%+v",
+			"target_duty=%.4f minimum_possible_duty=%.4f budget_saturated=%t "+
+			"intervals=%+v slowest_inputs=%+v",
 		snapshot.Inputs,
 		snapshot.Shortened,
 		snapshot.Multiplier,
 		snapshot.ScanDuty,
 		snapshot.TargetDuty,
+		snapshot.MinimumPossibleDuty,
+		snapshot.BudgetSaturated,
 		snapshot.Intervals,
 		snapshot.SlowestInputs,
 	)

--- a/utils/adaptive_scan.go
+++ b/utils/adaptive_scan.go
@@ -698,7 +698,7 @@ func logAdaptiveScanIntervalChange(record AdaptiveScanIntervalLog) {
 }
 
 func logAdaptiveScanSnapshot(snapshot AdaptiveScanSnapshot) {
-	logp.L.Infof(
+	logp.L.Debugf(
 		"adaptive scan snapshot: inputs=%d shortened=%d multiplier=%.3f scan_duty=%.4f "+
 			"target_duty=%.4f minimum_possible_duty=%.4f budget_saturated=%t "+
 			"intervals=%+v slowest_inputs=%+v",

--- a/utils/adaptive_scan.go
+++ b/utils/adaptive_scan.go
@@ -17,11 +17,15 @@ import (
 )
 
 const (
-	adaptiveScanEWMAAlpha        = 0.5
-	adaptiveScanDeadbandRatio    = 0.15
-	adaptiveScanMaxStepRatio     = 2.0
-	adaptiveScanMaxMultiplier    = 64.0
-	adaptiveScanInitialMultiple  = 1.0
+	// 同一个平滑系数同时用于单 input 扫描耗时和全局占空比，避免瞬时抖动直接改变周期。
+	adaptiveScanEWMAAlpha = 0.5
+	// 占空比落在目标值上下 15% 时不调整，防止 multiplier 在目标附近来回振荡。
+	adaptiveScanDeadbandRatio = 0.15
+	// 每轮控制将 multiplier 限制在当前值的 1/2 到 2 倍之间，并限制其最终上限。
+	adaptiveScanMaxStepRatio    = 2.0
+	adaptiveScanMaxMultiplier   = 64.0
+	adaptiveScanInitialMultiple = 1.0
+	// 变更日志按 input 限频，聚合快照则提供固定周期的全局视图。
 	adaptiveScanLogMinInterval   = time.Minute
 	adaptiveScanSnapshotInterval = 5 * time.Minute
 	adaptiveScanSnapshotTopK     = 5
@@ -98,19 +102,24 @@ type AdaptiveScanController struct {
 	controlInterval  time.Duration
 	targetDuty       float64
 
+	// mu 只保护各 Runner 的局部 EWMA、最终周期和日志状态。
 	mu     sync.Mutex
 	inputs map[uint64]*adaptiveScanInputState
 
+	// 热路径与 governor 通过原子值交换累计耗时、全局 multiplier 和最近占空比，
+	// 避免每个 Runner 在计算周期时争用 governor 的采样锁。
 	totalScanNanos atomic.Int64
 	multiplierBits atomic.Uint64
 	lastDutyBits   atomic.Uint64
 
+	// sampleMu 保护相邻采样点及占空比 EWMA，仅由 governor 周期更新。
 	sampleMu        sync.Mutex
 	lastSampleAt    time.Time
 	lastSampleTotal int64
 	smoothedDuty    float64
 	hasSmoothedDuty bool
 
+	// lifecycleMu 保证 Start/Stop 幂等，并避免重复创建或关闭后台 goroutine。
 	lifecycleMu sync.Mutex
 	running     bool
 	done        chan struct{}
@@ -158,6 +167,7 @@ func (c *AdaptiveScanController) NextInterval(inputID uint64, base, scanDuration
 		return base
 	}
 
+	// 累计值供 governor 按采样窗口计算所有 Runner 的聚合扫描占空比。
 	c.totalScanNanos.Add(int64(scanDuration))
 
 	c.mu.Lock()
@@ -177,12 +187,16 @@ func (c *AdaptiveScanController) NextInterval(inputID uint64, base, scanDuration
 		minimum = base
 	}
 
+	// 第一层局部控制：local = EWMA(scanDuration) / targetDuty。
+	// 例如目标占空比为 5%，一次扫描耗时 50ms，则局部周期应约为 1s。
 	localNanos := ewmaScanNanos / c.targetDuty
 	local := base
 	if localNanos < float64(base) {
 		local = clampDuration(time.Duration(localNanos), minimum, base)
 	}
 
+	// 第二层全局控制：所有 input 的局部周期统一乘以 governor 的 multiplier。
+	// 最终仍限制在 [minimum, base]，不会突破最小周期，也不会比原配置扫描得更慢。
 	effective := float64(local) * c.Multiplier()
 	var interval time.Duration
 	if effective >= float64(base) {
@@ -221,6 +235,7 @@ func (c *AdaptiveScanController) TotalScanDuration() time.Duration {
 }
 
 func (c *AdaptiveScanController) removeInput(inputID uint64) {
+	// Runner 完全停止后删除局部 EWMA，避免长期 Reload 积累已经失效的实例状态。
 	c.mu.Lock()
 	delete(c.inputs, inputID)
 	c.mu.Unlock()
@@ -268,6 +283,8 @@ func (c *AdaptiveScanController) Stop() {
 
 func (c *AdaptiveScanController) runGovernor(done <-chan struct{}) {
 	defer c.wg.Done()
+	// control ticker 调整全局 multiplier；snapshot ticker 只负责诊断输出，
+	// 两者分离可避免日志周期影响控制收敛速度。
 	ticker := time.NewTicker(c.controlInterval)
 	defer ticker.Stop()
 	snapshotTicker := time.NewTicker(c.snapshotInterval)
@@ -288,6 +305,7 @@ func (c *AdaptiveScanController) runGovernor(done <-chan struct{}) {
 
 func (c *AdaptiveScanController) observeSample(now time.Time, totalNanos int64) {
 	c.sampleMu.Lock()
+	// 累计值倒退表示采样基线已失效，只重置基线，不用异常窗口更新 multiplier。
 	if c.lastSampleAt.IsZero() || totalNanos < c.lastSampleTotal {
 		c.lastSampleAt = now
 		c.lastSampleTotal = totalNanos
@@ -304,6 +322,7 @@ func (c *AdaptiveScanController) observeSample(now time.Time, totalNanos int64) 
 		c.sampleMu.Unlock()
 		return
 	}
+	// 聚合占空比 = 采样窗口内所有扫描耗时增量 / 实际墙钟时间。
 	duty := float64(deltaNanos) / float64(elapsed)
 	if c.hasSmoothedDuty {
 		c.smoothedDuty = adaptiveScanEWMAAlpha*duty +
@@ -329,11 +348,14 @@ func (c *AdaptiveScanController) updateMultiplier(duty float64) {
 	}
 
 	current := c.Multiplier()
+	// 目标附近保留 15% 死区，避免扫描耗时的小幅波动导致周期频繁变化。
 	if duty >= c.targetDuty*(1-adaptiveScanDeadbandRatio) &&
 		duty <= c.targetDuty*(1+adaptiveScanDeadbandRatio) {
 		return
 	}
 
+	// 按 duty/target 的比例反推新 multiplier，再限制单次最大步长并做一次 EWMA。
+	// 这样既能在超预算时及时降频，也不会因单个异常采样突然跳到极端值。
 	target := current * duty / c.targetDuty
 	target = clampFloat(target, 1, adaptiveScanMaxMultiplier)
 	target = clampFloat(target, current/adaptiveScanMaxStepRatio, current*adaptiveScanMaxStepRatio)
@@ -358,6 +380,8 @@ func (c *AdaptiveScanController) maybeLogIntervalChange(
 		c.mu.Unlock()
 		return
 	}
+	// 首次仅在周期确实缩短或 Beats 发生兜底时打印；之后至少间隔一分钟，
+	// 且只有倍数变化或跨固定周期桶时才打印，兼顾可诊断性与日志量。
 	shouldLog := (state.lastLoggedInterval == 0 && (effective < base || requested != effective)) ||
 		(state.lastLoggedInterval != 0 &&
 			now.Sub(state.lastLogAt) >= adaptiveScanLogMinInterval &&

--- a/utils/adaptive_scan_metadata.go
+++ b/utils/adaptive_scan_metadata.go
@@ -1,0 +1,133 @@
+// Tencent is pleased to support the open source community by making bkunifylogbeat 蓝鲸日志采集器 available.
+//
+// Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License.
+
+package utils
+
+import (
+	"sort"
+	"sync"
+	"sync/atomic"
+)
+
+// AdaptiveScanInputMetadata 描述与 Filebeat Runner 关联的任务配置。
+// 多个任务可能共享同一个 input Runner。
+type AdaptiveScanInputMetadata struct {
+	InputID string
+	TaskID  string
+	DataID  int
+	Paths   []string
+}
+
+type adaptiveScanInputMetadataSnapshot struct {
+	InputID string
+	TaskIDs []string
+	DataIDs []int
+	Paths   []string
+}
+
+type adaptiveScanInputMetadataState struct {
+	inputID string
+	tasks   map[string]AdaptiveScanInputMetadata
+}
+
+var adaptiveScanMetadataRegistry = struct {
+	sync.RWMutex
+	inputs map[uint64]*adaptiveScanInputMetadataState
+}{
+	inputs: make(map[uint64]*adaptiveScanInputMetadataState),
+}
+
+var activeAdaptiveScanController atomic.Pointer[AdaptiveScanController]
+
+// SetActiveAdaptiveScanController 设置接收 Runner 清理通知的当前控制器。
+func SetActiveAdaptiveScanController(controller *AdaptiveScanController) {
+	activeAdaptiveScanController.Store(controller)
+}
+
+// RegisterAdaptiveScanInput 将任务元数据关联到 Runner。
+func RegisterAdaptiveScanInput(runnerID uint64, metadata AdaptiveScanInputMetadata) {
+	adaptiveScanMetadataRegistry.Lock()
+	defer adaptiveScanMetadataRegistry.Unlock()
+
+	state, ok := adaptiveScanMetadataRegistry.inputs[runnerID]
+	if !ok {
+		state = &adaptiveScanInputMetadataState{
+			tasks: make(map[string]AdaptiveScanInputMetadata),
+		}
+		adaptiveScanMetadataRegistry.inputs[runnerID] = state
+	}
+	if metadata.InputID != "" {
+		state.inputID = metadata.InputID
+	}
+	metadata.Paths = append([]string(nil), metadata.Paths...)
+	state.tasks[metadata.TaskID] = metadata
+}
+
+// UnregisterAdaptiveScanTask 从共享 Runner 的元数据中移除一个任务。
+func UnregisterAdaptiveScanTask(runnerID uint64, metadata AdaptiveScanInputMetadata) {
+	adaptiveScanMetadataRegistry.Lock()
+	defer adaptiveScanMetadataRegistry.Unlock()
+
+	state, ok := adaptiveScanMetadataRegistry.inputs[runnerID]
+	if !ok {
+		return
+	}
+	delete(state.tasks, metadata.TaskID)
+	if len(state.tasks) == 0 {
+		delete(adaptiveScanMetadataRegistry.inputs, runnerID)
+	}
+}
+
+// UnregisterAdaptiveScanInput 移除与 Runner 关联的全部元数据。
+func UnregisterAdaptiveScanInput(runnerID uint64) {
+	adaptiveScanMetadataRegistry.Lock()
+	delete(adaptiveScanMetadataRegistry.inputs, runnerID)
+	adaptiveScanMetadataRegistry.Unlock()
+
+	if controller := activeAdaptiveScanController.Load(); controller != nil {
+		controller.removeInput(runnerID)
+	}
+}
+
+func adaptiveScanInputMetadata(runnerID uint64) (adaptiveScanInputMetadataSnapshot, bool) {
+	adaptiveScanMetadataRegistry.RLock()
+	state, ok := adaptiveScanMetadataRegistry.inputs[runnerID]
+	if !ok {
+		adaptiveScanMetadataRegistry.RUnlock()
+		return adaptiveScanInputMetadataSnapshot{}, false
+	}
+
+	snapshot := adaptiveScanInputMetadataSnapshot{
+		InputID: state.inputID,
+		TaskIDs: make([]string, 0, len(state.tasks)),
+	}
+	dataIDs := make(map[int]struct{})
+	paths := make(map[string]struct{})
+	for _, metadata := range state.tasks {
+		if metadata.TaskID != "" {
+			snapshot.TaskIDs = append(snapshot.TaskIDs, metadata.TaskID)
+		}
+		if metadata.DataID != 0 {
+			dataIDs[metadata.DataID] = struct{}{}
+		}
+		for _, path := range metadata.Paths {
+			if path != "" {
+				paths[path] = struct{}{}
+			}
+		}
+	}
+	for dataID := range dataIDs {
+		snapshot.DataIDs = append(snapshot.DataIDs, dataID)
+	}
+	for path := range paths {
+		snapshot.Paths = append(snapshot.Paths, path)
+	}
+	adaptiveScanMetadataRegistry.RUnlock()
+
+	sort.Strings(snapshot.TaskIDs)
+	sort.Ints(snapshot.DataIDs)
+	sort.Strings(snapshot.Paths)
+	return snapshot, true
+}

--- a/utils/adaptive_scan_metadata.go
+++ b/utils/adaptive_scan_metadata.go
@@ -32,6 +32,8 @@ type adaptiveScanInputMetadataState struct {
 	tasks   map[string]AdaptiveScanInputMetadata
 }
 
+// metadata registry 只服务诊断日志，按 Runner 聚合同一 input 下的多个任务；
+// active controller 则用于在 Runner 销毁时同步清理控制器中的局部计算状态。
 var adaptiveScanMetadataRegistry = struct {
 	sync.RWMutex
 	inputs map[uint64]*adaptiveScanInputMetadataState
@@ -70,6 +72,8 @@ func UnregisterAdaptiveScanTask(runnerID uint64, metadata AdaptiveScanInputMetad
 	adaptiveScanMetadataRegistry.Lock()
 	defer adaptiveScanMetadataRegistry.Unlock()
 
+	// Task 停止不等于 Runner 停止：共享 input 仍可能继续服务其他任务，
+	// 因此这里只移除当前 Task，最后一个 Task 离开时才删除 Runner 元数据。
 	state, ok := adaptiveScanMetadataRegistry.inputs[runnerID]
 	if !ok {
 		return
@@ -86,6 +90,7 @@ func UnregisterAdaptiveScanInput(runnerID uint64) {
 	delete(adaptiveScanMetadataRegistry.inputs, runnerID)
 	adaptiveScanMetadataRegistry.Unlock()
 
+	// 不在 registry 锁内调用 controller，避免把两套状态的锁顺序耦合在一起。
 	if controller := activeAdaptiveScanController.Load(); controller != nil {
 		controller.removeInput(runnerID)
 	}

--- a/utils/adaptive_scan_test.go
+++ b/utils/adaptive_scan_test.go
@@ -1,0 +1,345 @@
+// Tencent is pleased to support the open source community by making bkunifylogbeat 蓝鲸日志采集器 available.
+//
+// Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License.
+
+package utils
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestAdaptiveScanController(t *testing.T) *AdaptiveScanController {
+	t.Helper()
+	controller, err := NewAdaptiveScanController(AdaptiveScanSettings{
+		MinScanFrequency: 500 * time.Millisecond,
+		ScanCPUPercent:   5,
+		ControlInterval:  3 * time.Second,
+	})
+	assert.NoError(t, err)
+	controller.logIntervalChange = func(AdaptiveScanIntervalLog) {}
+	controller.logSnapshot = func(AdaptiveScanSnapshot) {}
+	controller.logInputSnapshots = func([]AdaptiveScanIntervalLog) {}
+	return controller
+}
+
+func nextAndObserve(
+	controller *AdaptiveScanController,
+	runnerID uint64,
+	base, scanDuration time.Duration,
+) time.Duration {
+	requested := controller.NextInterval(runnerID, base, scanDuration)
+	controller.ObserveApplied(runnerID, base, requested, requested, scanDuration)
+	return requested
+}
+
+func TestAdaptiveScanControllerUsesFirstSampleImmediately(t *testing.T) {
+	controller := newTestAdaptiveScanController(t)
+
+	got := controller.NextInterval(1, 10*time.Second, time.Millisecond)
+
+	assert.Equal(t, 500*time.Millisecond, got)
+	assert.Equal(t, time.Millisecond, controller.TotalScanDuration())
+}
+
+func TestAdaptiveScanControllerKeepsIndependentEWMAByInput(t *testing.T) {
+	controller := newTestAdaptiveScanController(t)
+
+	assert.Equal(t, 2*time.Second, controller.NextInterval(1, 10*time.Second, 100*time.Millisecond))
+	assert.Equal(t, 3*time.Second, controller.NextInterval(1, 10*time.Second, 200*time.Millisecond))
+	assert.Equal(t, 4*time.Second, controller.NextInterval(2, 10*time.Second, 200*time.Millisecond))
+}
+
+func TestAdaptiveScanControllerClampsToConfiguredBounds(t *testing.T) {
+	controller := newTestAdaptiveScanController(t)
+
+	assert.Equal(t, 10*time.Second, controller.NextInterval(1, 10*time.Second, time.Second))
+	assert.Equal(t, 200*time.Millisecond, controller.NextInterval(2, 200*time.Millisecond, time.Millisecond))
+	assert.Equal(t, 10*time.Second, controller.NextInterval(3, 10*time.Second, 0))
+	assert.Equal(t, 10*time.Second, controller.NextInterval(3, 10*time.Second, -time.Second))
+}
+
+func TestAdaptiveScanControllerMultiplierNeverExceedsBase(t *testing.T) {
+	controller := newTestAdaptiveScanController(t)
+	controller.updateMultiplier(20 * controller.targetDuty)
+
+	got := controller.NextInterval(1, time.Second, 40*time.Millisecond)
+
+	assert.Equal(t, time.Second, got)
+}
+
+func TestAdaptiveScanGovernorDeadbandAndStepLimit(t *testing.T) {
+	controller := newTestAdaptiveScanController(t)
+
+	controller.updateMultiplier(controller.targetDuty * 1.10)
+	assert.Equal(t, float64(1), controller.Multiplier())
+
+	controller.updateMultiplier(controller.targetDuty * 4)
+	assert.InDelta(t, 1.5, controller.Multiplier(), 0.0001)
+}
+
+func TestAdaptiveScanGovernorRecoversTowardOne(t *testing.T) {
+	controller := newTestAdaptiveScanController(t)
+	controller.updateMultiplier(controller.targetDuty * 4)
+	controller.updateMultiplier(controller.targetDuty * 4)
+	before := controller.Multiplier()
+
+	controller.updateMultiplier(controller.targetDuty * 0.1)
+
+	assert.Less(t, controller.Multiplier(), before)
+	assert.GreaterOrEqual(t, controller.Multiplier(), float64(1))
+}
+
+func TestAdaptiveScanGovernorSamplesAccumulatedDuty(t *testing.T) {
+	controller := newTestAdaptiveScanController(t)
+	start := time.Unix(100, 0)
+
+	controller.observeSample(start, 0)
+	controller.observeSample(start.Add(time.Second), int64(200*time.Millisecond))
+
+	assert.InDelta(t, 1.5, controller.Multiplier(), 0.0001)
+}
+
+func TestAdaptiveScanGovernorSmoothsAggregateDuty(t *testing.T) {
+	controller := newTestAdaptiveScanController(t)
+	start := time.Unix(100, 0)
+
+	controller.observeSample(start, 0)
+	controller.observeSample(start.Add(time.Second), int64(200*time.Millisecond))
+	controller.observeSample(start.Add(2*time.Second), int64(200*time.Millisecond))
+
+	assert.InDelta(t, 0.1, math.Float64frombits(controller.lastDutyBits.Load()), 0.0001)
+	assert.Greater(t, controller.Multiplier(), 1.5)
+}
+
+func TestAdaptiveScanGovernorStartStopIsIdempotent(t *testing.T) {
+	controller, err := NewAdaptiveScanController(AdaptiveScanSettings{
+		MinScanFrequency: 500 * time.Millisecond,
+		ScanCPUPercent:   5,
+		ControlInterval:  10 * time.Millisecond,
+	})
+	assert.NoError(t, err)
+
+	controller.Start()
+	controller.Start()
+	controller.NextInterval(1, 10*time.Second, 100*time.Millisecond)
+
+	deadline := time.Now().Add(time.Second)
+	for controller.Multiplier() == 1 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	assert.True(t, controller.Multiplier() > 1)
+
+	controller.Stop()
+	controller.Stop()
+}
+
+func TestNewAdaptiveScanControllerRejectsInvalidSettings(t *testing.T) {
+	tests := []AdaptiveScanSettings{
+		{MinScanFrequency: 0, ScanCPUPercent: 5, ControlInterval: time.Second},
+		{MinScanFrequency: time.Second, ScanCPUPercent: 0, ControlInterval: time.Second},
+		{MinScanFrequency: time.Second, ScanCPUPercent: 101, ControlInterval: time.Second},
+		{MinScanFrequency: time.Second, ScanCPUPercent: math.NaN(), ControlInterval: time.Second},
+		{MinScanFrequency: time.Second, ScanCPUPercent: math.Inf(1), ControlInterval: time.Second},
+		{MinScanFrequency: time.Second, ScanCPUPercent: 5, ControlInterval: 0},
+	}
+	for _, settings := range tests {
+		_, err := NewAdaptiveScanController(settings)
+		assert.Error(t, err)
+	}
+}
+
+func TestAdaptiveScanInputMetadataMergesSharedInput(t *testing.T) {
+	const runnerID = uint64(123)
+	defer UnregisterAdaptiveScanInput(runnerID)
+
+	RegisterAdaptiveScanInput(runnerID, AdaptiveScanInputMetadata{
+		InputID: "input-a",
+		TaskID:  "task-a",
+		DataID:  1001,
+		Paths:   []string{"/var/log/a.log"},
+	})
+	RegisterAdaptiveScanInput(runnerID, AdaptiveScanInputMetadata{
+		InputID: "input-a",
+		TaskID:  "task-b",
+		DataID:  1002,
+		Paths:   []string{"/var/log/a.log"},
+	})
+
+	metadata, ok := adaptiveScanInputMetadata(runnerID)
+	assert.True(t, ok)
+	assert.Equal(t, "input-a", metadata.InputID)
+	assert.ElementsMatch(t, []string{"task-a", "task-b"}, metadata.TaskIDs)
+	assert.ElementsMatch(t, []int{1001, 1002}, metadata.DataIDs)
+	assert.Equal(t, []string{"/var/log/a.log"}, metadata.Paths)
+
+	UnregisterAdaptiveScanTask(runnerID, AdaptiveScanInputMetadata{TaskID: "task-a"})
+	metadata, ok = adaptiveScanInputMetadata(runnerID)
+	assert.True(t, ok)
+	assert.Equal(t, []string{"task-b"}, metadata.TaskIDs)
+	assert.Equal(t, []int{1002}, metadata.DataIDs)
+
+	UnregisterAdaptiveScanInput(runnerID)
+	_, ok = adaptiveScanInputMetadata(runnerID)
+	assert.False(t, ok)
+}
+
+func TestAdaptiveScanControllerLogsMeaningfulIntervalChanges(t *testing.T) {
+	const runnerID = uint64(456)
+	defer UnregisterAdaptiveScanInput(runnerID)
+	RegisterAdaptiveScanInput(runnerID, AdaptiveScanInputMetadata{
+		InputID: "input-a",
+		TaskID:  "task-a",
+		DataID:  1001,
+		Paths:   []string{"/var/log/app.log"},
+	})
+
+	controller := newTestAdaptiveScanController(t)
+	now := time.Unix(100, 0)
+	controller.now = func() time.Time { return now }
+	var records []AdaptiveScanIntervalLog
+	controller.logIntervalChange = func(record AdaptiveScanIntervalLog) {
+		records = append(records, record)
+	}
+
+	nextAndObserve(controller, runnerID, 10*time.Second, time.Millisecond)
+	assert.Len(t, records, 1)
+	assert.Equal(t, "input-a", records[0].InputID)
+	assert.Equal(t, []string{"task-a"}, records[0].TaskIDs)
+	assert.Equal(t, []int{1001}, records[0].DataIDs)
+	assert.Equal(t, 500*time.Millisecond, records[0].RequestedInterval)
+	assert.Equal(t, 500*time.Millisecond, records[0].EffectiveInterval)
+
+	now = now.Add(10 * time.Second)
+	nextAndObserve(controller, runnerID, 10*time.Second, 100*time.Millisecond)
+	assert.Len(t, records, 1)
+
+	now = now.Add(61 * time.Second)
+	nextAndObserve(controller, runnerID, 10*time.Second, 100*time.Millisecond)
+	assert.Len(t, records, 2)
+	assert.Equal(t, 1505*time.Millisecond, records[1].EffectiveInterval)
+}
+
+func TestAdaptiveScanControllerDoesNotLogUnchangedInitialInterval(t *testing.T) {
+	const runnerID = uint64(457)
+	defer UnregisterAdaptiveScanInput(runnerID)
+	RegisterAdaptiveScanInput(runnerID, AdaptiveScanInputMetadata{
+		InputID: "input-expensive",
+		TaskID:  "task-expensive",
+		DataID:  1002,
+	})
+
+	controller := newTestAdaptiveScanController(t)
+	var records []AdaptiveScanIntervalLog
+	controller.logIntervalChange = func(record AdaptiveScanIntervalLog) {
+		records = append(records, record)
+	}
+
+	assert.Equal(t, 10*time.Second, nextAndObserve(controller, runnerID, 10*time.Second, time.Second))
+	assert.Empty(t, records)
+}
+
+func TestAdaptiveScanControllerRecordsFinalAppliedInterval(t *testing.T) {
+	const runnerID = uint64(458)
+	RegisterAdaptiveScanInput(runnerID, AdaptiveScanInputMetadata{
+		InputID: "input-fallback",
+		TaskID:  "task-fallback",
+		DataID:  1003,
+	})
+	defer UnregisterAdaptiveScanInput(runnerID)
+	controller := newTestAdaptiveScanController(t)
+	var records []AdaptiveScanIntervalLog
+	controller.logIntervalChange = func(record AdaptiveScanIntervalLog) {
+		records = append(records, record)
+	}
+	controller.NextInterval(runnerID, 10*time.Second, time.Millisecond)
+
+	controller.ObserveApplied(
+		runnerID,
+		10*time.Second,
+		11*time.Second,
+		10*time.Second,
+		time.Millisecond,
+	)
+
+	inputs := controller.inputSnapshots()
+	assert.Len(t, inputs, 1)
+	assert.Equal(t, 11*time.Second, inputs[0].RequestedInterval)
+	assert.Equal(t, 10*time.Second, inputs[0].EffectiveInterval)
+	assert.Len(t, records, 1)
+	assert.Equal(t, 11*time.Second, records[0].RequestedInterval)
+	assert.Equal(t, 10*time.Second, records[0].EffectiveInterval)
+}
+
+func TestUnregisterAdaptiveScanInputRemovesControllerState(t *testing.T) {
+	const runnerID = uint64(789)
+	controller := newTestAdaptiveScanController(t)
+	controller.NextInterval(runnerID, 10*time.Second, time.Millisecond)
+	SetActiveAdaptiveScanController(controller)
+	defer SetActiveAdaptiveScanController(nil)
+
+	UnregisterAdaptiveScanInput(runnerID)
+
+	controller.mu.Lock()
+	_, ok := controller.inputs[runnerID]
+	controller.mu.Unlock()
+	assert.False(t, ok)
+}
+
+func TestAdaptiveScanControllerBuildsBoundedAggregateSnapshot(t *testing.T) {
+	runnerIDs := []uint64{801, 802, 803}
+	for index, runnerID := range runnerIDs {
+		RegisterAdaptiveScanInput(runnerID, AdaptiveScanInputMetadata{
+			InputID: "input-" + string(rune('a'+index)),
+			TaskID:  "task-" + string(rune('a'+index)),
+			DataID:  1001 + index,
+			Paths:   []string{"/var/log/app.log"},
+		})
+		defer UnregisterAdaptiveScanInput(runnerID)
+	}
+
+	controller := newTestAdaptiveScanController(t)
+	nextAndObserve(controller, runnerIDs[0], 10*time.Second, time.Millisecond)
+	nextAndObserve(controller, runnerIDs[1], 10*time.Second, 100*time.Millisecond)
+	nextAndObserve(controller, runnerIDs[2], 10*time.Second, time.Second)
+	controller.observeSample(time.Unix(100, 0), 0)
+	controller.observeSample(time.Unix(101, 0), int64(30*time.Millisecond))
+
+	snapshot := controller.snapshot()
+
+	assert.Equal(t, 3, snapshot.Inputs)
+	assert.Equal(t, 2, snapshot.Shortened)
+	assert.Equal(t, 1, snapshot.Intervals.AtMinimum)
+	assert.Equal(t, 1, snapshot.Intervals.UpTo2Seconds)
+	assert.Equal(t, 1, snapshot.Intervals.AtBase)
+	assert.InDelta(t, 0.03, snapshot.ScanDuty, 0.0001)
+	assert.Len(t, snapshot.SlowestInputs, 3)
+	assert.Equal(t, runnerIDs[2], snapshot.SlowestInputs[0].RunnerID)
+
+	inputs := controller.inputSnapshots()
+	assert.Len(t, inputs, 3)
+	assert.Equal(t, runnerIDs[0], inputs[0].RunnerID)
+	assert.Equal(t, []string{"/var/log/app.log"}, inputs[0].Paths)
+}
+
+func TestAdaptiveScanControllerLogsPeriodicSnapshot(t *testing.T) {
+	controller := newTestAdaptiveScanController(t)
+	controller.snapshotInterval = 10 * time.Millisecond
+	logged := make(chan AdaptiveScanSnapshot, 1)
+	controller.logSnapshot = func(snapshot AdaptiveScanSnapshot) {
+		logged <- snapshot
+	}
+
+	controller.Start()
+	defer controller.Stop()
+
+	select {
+	case <-logged:
+	case <-time.After(time.Second):
+		t.Fatal("periodic adaptive scan snapshot was not logged")
+	}
+}

--- a/utils/adaptive_scan_test.go
+++ b/utils/adaptive_scan_test.go
@@ -65,32 +65,141 @@ func TestAdaptiveScanControllerClampsToConfiguredBounds(t *testing.T) {
 
 func TestAdaptiveScanControllerMultiplierNeverExceedsBase(t *testing.T) {
 	controller := newTestAdaptiveScanController(t)
-	controller.updateMultiplier(20 * controller.targetDuty)
+	controller.NextInterval(1, time.Second, 40*time.Millisecond)
+	controller.setMultiplier(20)
 
 	got := controller.NextInterval(1, time.Second, 40*time.Millisecond)
 
 	assert.Equal(t, time.Second, got)
 }
 
-func TestAdaptiveScanGovernorDeadbandAndStepLimit(t *testing.T) {
+func TestAdaptiveScanGovernorDeadband(t *testing.T) {
 	controller := newTestAdaptiveScanController(t)
+	for runnerID := uint64(1); runnerID <= 100; runnerID++ {
+		nextAndObserve(controller, runnerID, 300*time.Second, 10*time.Millisecond)
+	}
+	controller.setMultiplier(40)
 
-	controller.updateMultiplier(controller.targetDuty * 1.10)
+	controller.updateMultiplier()
+
+	assert.Equal(t, float64(40), controller.Multiplier())
+}
+
+func TestAdaptiveScanGovernorConvergesWithOneHundredInputs(t *testing.T) {
+	controller, err := NewAdaptiveScanController(AdaptiveScanSettings{
+		MinScanFrequency: time.Second,
+		ScanCPUPercent:   5,
+		ControlInterval:  3 * time.Second,
+	})
+	assert.NoError(t, err)
+
+	const inputs = 100
+	base := 300 * time.Second
+	scanDuration := 10 * time.Millisecond
+	for runnerID := uint64(1); runnerID <= inputs; runnerID++ {
+		nextAndObserve(controller, runnerID, base, scanDuration)
+	}
+
+	for range 2 {
+		controller.updateMultiplier()
+	}
+
+	assert.InDelta(t, 20, controller.Multiplier(), 0.1)
+	interval := controller.NextInterval(1, base, scanDuration)
+	assert.InDelta(t, 20*time.Second, interval, float64(time.Millisecond))
+	assert.InDelta(t, controller.targetDuty, float64(inputs)*float64(scanDuration)/float64(interval), 0.0001)
+}
+
+func TestAdaptiveScanGovernorConvergesAboveLegacyCap(t *testing.T) {
+	controller, err := NewAdaptiveScanController(AdaptiveScanSettings{
+		MinScanFrequency: time.Second,
+		ScanCPUPercent:   5,
+		ControlInterval:  3 * time.Second,
+	})
+	assert.NoError(t, err)
+
+	const inputs = 1000
+	base := 300 * time.Second
+	scanDuration := 10 * time.Millisecond
+	for runnerID := uint64(1); runnerID <= inputs; runnerID++ {
+		nextAndObserve(controller, runnerID, base, scanDuration)
+	}
+
+	for range 3 {
+		controller.updateMultiplier()
+	}
+
+	assert.InDelta(t, 200, controller.Multiplier(), 0.1)
+	assert.Greater(t, controller.Multiplier(), float64(64))
+	interval := controller.NextInterval(1, base, scanDuration)
+	assert.InDelta(t, 200*time.Second, interval, float64(time.Millisecond))
+	assert.InDelta(t, controller.targetDuty, float64(inputs)*float64(scanDuration)/float64(interval), 0.0001)
+}
+
+func TestAdaptiveScanGovernorStopsAtDynamicLimitWhenBudgetIsImpossible(t *testing.T) {
+	controller, err := NewAdaptiveScanController(AdaptiveScanSettings{
+		MinScanFrequency: time.Second,
+		ScanCPUPercent:   5,
+		ControlInterval:  3 * time.Second,
+	})
+	assert.NoError(t, err)
+
+	const inputs = 1000
+	base := 100 * time.Second
+	scanDuration := 10 * time.Millisecond
+	for runnerID := uint64(1); runnerID <= inputs; runnerID++ {
+		nextAndObserve(controller, runnerID, base, scanDuration)
+	}
+
+	for range 5 {
+		controller.updateMultiplier()
+	}
+
+	assert.InDelta(t, 100, controller.Multiplier(), 0.1)
+	assert.Equal(t, base, controller.NextInterval(1, base, scanDuration))
+	snapshot := controller.snapshot()
+	assert.True(t, snapshot.BudgetSaturated)
+	assert.InDelta(t, 0.10, snapshot.MinimumPossibleDuty, 0.0001)
+}
+
+func TestAdaptiveScanGovernorResetsWithoutActiveInputs(t *testing.T) {
+	controller := newTestAdaptiveScanController(t)
+	for runnerID := uint64(1); runnerID <= 100; runnerID++ {
+		controller.NextInterval(runnerID, 10*time.Second, 10*time.Millisecond)
+	}
+	controller.updateMultiplier()
+	assert.Greater(t, controller.Multiplier(), float64(1))
+
+	for runnerID := uint64(1); runnerID <= 100; runnerID++ {
+		controller.removeInput(runnerID)
+	}
+	controller.updateMultiplier()
+
 	assert.Equal(t, float64(1), controller.Multiplier())
-
-	controller.updateMultiplier(controller.targetDuty * 4)
-	assert.InDelta(t, 1.5, controller.Multiplier(), 0.0001)
+	assert.False(t, controller.snapshot().BudgetSaturated)
 }
 
 func TestAdaptiveScanGovernorRecoversTowardOne(t *testing.T) {
-	controller := newTestAdaptiveScanController(t)
-	controller.updateMultiplier(controller.targetDuty * 4)
-	controller.updateMultiplier(controller.targetDuty * 4)
+	controller, err := NewAdaptiveScanController(AdaptiveScanSettings{
+		MinScanFrequency: time.Second,
+		ScanCPUPercent:   5,
+		ControlInterval:  3 * time.Second,
+	})
+	assert.NoError(t, err)
+	for runnerID := uint64(1); runnerID <= 100; runnerID++ {
+		nextAndObserve(controller, runnerID, 300*time.Second, 10*time.Millisecond)
+	}
+	controller.updateMultiplier()
+	controller.updateMultiplier()
 	before := controller.Multiplier()
 
-	controller.updateMultiplier(controller.targetDuty * 0.1)
+	for runnerID := uint64(51); runnerID <= 100; runnerID++ {
+		controller.removeInput(runnerID)
+	}
+	controller.updateMultiplier()
 
 	assert.Less(t, controller.Multiplier(), before)
+	assert.GreaterOrEqual(t, controller.Multiplier(), float64(10))
 	assert.GreaterOrEqual(t, controller.Multiplier(), float64(1))
 }
 
@@ -101,7 +210,8 @@ func TestAdaptiveScanGovernorSamplesAccumulatedDuty(t *testing.T) {
 	controller.observeSample(start, 0)
 	controller.observeSample(start.Add(time.Second), int64(200*time.Millisecond))
 
-	assert.InDelta(t, 1.5, controller.Multiplier(), 0.0001)
+	assert.InDelta(t, 0.2, math.Float64frombits(controller.lastDutyBits.Load()), 0.0001)
+	assert.Equal(t, float64(1), controller.Multiplier())
 }
 
 func TestAdaptiveScanGovernorSmoothsAggregateDuty(t *testing.T) {
@@ -113,7 +223,7 @@ func TestAdaptiveScanGovernorSmoothsAggregateDuty(t *testing.T) {
 	controller.observeSample(start.Add(2*time.Second), int64(200*time.Millisecond))
 
 	assert.InDelta(t, 0.1, math.Float64frombits(controller.lastDutyBits.Load()), 0.0001)
-	assert.Greater(t, controller.Multiplier(), 1.5)
+	assert.Equal(t, float64(1), controller.Multiplier())
 }
 
 func TestAdaptiveScanGovernorStartStopIsIdempotent(t *testing.T) {
@@ -124,9 +234,11 @@ func TestAdaptiveScanGovernorStartStopIsIdempotent(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
+	for runnerID := uint64(1); runnerID <= 100; runnerID++ {
+		controller.NextInterval(runnerID, 300*time.Second, 10*time.Millisecond)
+	}
 	controller.Start()
 	controller.Start()
-	controller.NextInterval(1, 10*time.Second, 100*time.Millisecond)
 
 	deadline := time.Now().Add(time.Second)
 	for controller.Multiplier() == 1 && time.Now().Before(deadline) {


### PR DESCRIPTION
## Summary
- 根据每个文件 input 的实测扫描耗时动态缩短扫描周期，并以原配置周期作为上限
- 增加全局扫描占空比 governor、最终生效周期回传及带任务上下文的限频诊断日志
- 默认开启该能力，最小扫描周期为 `1s`，并升级 Beats 依赖至 `v7.1.54-bk`

## Test plan
- [x] `GOTOOLCHAIN=go1.24.11 go test -race ./config ./utils ./beater ./task/input -count=1 -run 'TestParseAdaptiveScan|TestAdaptiveScan|TestNewAdaptiveScan|TestUnregisterAdaptive|TestManagerConfigureAdaptiveScan'`
- [x] `GOTOOLCHAIN=go1.24.11 go test ./config -count=1`
- [x] `GOTOOLCHAIN=go1.24.11 go test ./... -run '^$' -count=1`
- [x] `GOTOOLCHAIN=go1.24.11 go mod verify`