### PR TITLE
feat: 自适应扫描预算适配容器 CPU 配额 --story=136436214

### DIFF
--- a/bkunifylogbeat.reference.yml
+++ b/bkunifylogbeat.reference.yml
@@ -21,8 +21,8 @@ bkunifylogbeat.buffertimeout: 2
 bkunifylogbeat.eventdataid: -1
 bkunifylogbeat.max_cpu_limit: -1
 bkunifylogbeat.cpu_check_times: 10
-# 根据实际扫描耗时动态缩短各文件 input 的扫描周期，并将聚合扫描开销
-# 控制在配置的单核 CPU 预算内。默认开启。
+# 根据实际扫描耗时动态缩短各文件 input 的扫描周期，并将聚合扫描墙钟耗时
+# 控制在配置的单核预算内；容器 CPU quota 小于 1 核时预算会等比例缩小。默认开启。
 #bkunifylogbeat.adaptive_scan:
 #  enabled: true
 #  min_scan_frequency: "1s"
@@ -104,5 +104,4 @@ bkunifylogbeat.local:
       - grep:
           key_name: "event_id"
           regex: "keep records by regex"
-
 

--- a/config/config.go
+++ b/config/config.go
@@ -71,7 +71,8 @@ type AdaptiveScanConfig struct {
 	Enabled bool `config:"enabled"`
 	// MinScanFrequency 是动态缩短后的下限；若原配置周期更短，仍以原配置为准。
 	MinScanFrequency time.Duration `config:"min_scan_frequency"`
-	// ScanCPUPercent 是所有 input 聚合扫描耗时占单核时间的目标比例，不是单 input 配额。
+	// ScanCPUPercent 是所有 input 聚合扫描墙钟耗时占单核时间的目标比例，不是进程 CPU 使用率；
+	// 当容器 CPU quota 小于 1 核时，会按 quota 等比例缩小预算。
 	ScanCPUPercent float64 `config:"scan_cpu_percent"`
 	// ControlInterval 是 governor 的采样与调节周期，与文件扫描周期相互独立。
 	ControlInterval time.Duration `config:"control_interval"`

--- a/utils/adaptive_scan.go
+++ b/utils/adaptive_scan.go
@@ -36,8 +36,8 @@ const (
 	adaptiveScanSnapshotTopK     = 5
 )
 
-// AdaptiveScanSettings 控制单 input 周期计算和全局扫描 CPU 预算。
-// ScanCPUPercent 表示扫描耗时占单核时间的百分比。
+// AdaptiveScanSettings 控制单 input 周期计算和全局扫描工作预算。
+// ScanCPUPercent 表示扫描墙钟耗时占单核时间的百分比；它是扫描开销代理，不是进程 CPU 使用率。
 type AdaptiveScanSettings struct {
 	MinScanFrequency time.Duration
 	ScanCPUPercent   float64
@@ -67,6 +67,9 @@ type AdaptiveScanIntervalLog struct {
 	EffectiveInterval time.Duration
 	Multiplier        float64
 	ScanDuration      time.Duration
+	TargetDuty        float64
+	EffectiveCores    float64
+	CPUCapacitySource string
 }
 
 // AdaptiveScanIntervalDistribution 是周期快照中固定桶数的扫描周期分布。
@@ -93,11 +96,14 @@ type AdaptiveScanSnapshotInput struct {
 
 // AdaptiveScanSnapshot 表示一条固定大小的控制器聚合快照。
 type AdaptiveScanSnapshot struct {
-	Inputs     int
-	Shortened  int
-	Multiplier float64
-	ScanDuty   float64
-	TargetDuty float64
+	Inputs               int
+	Shortened            int
+	Multiplier           float64
+	ScanDuty             float64
+	ConfiguredTargetDuty float64
+	TargetDuty           float64
+	EffectiveCores       float64
+	CPUCapacitySource    string
 	// MinimumPossibleDuty 是所有活跃 input 都退回基础周期后的最低聚合扫描占空比。
 	MinimumPossibleDuty float64
 	// BudgetSaturated 表示基础周期上限使目标预算无法满足。
@@ -108,9 +114,12 @@ type AdaptiveScanSnapshot struct {
 
 // AdaptiveScanController 计算每个 input 的扫描周期，并维护限制聚合扫描开销的全局乘数。
 type AdaptiveScanController struct {
-	minScanFrequency time.Duration
-	controlInterval  time.Duration
-	targetDuty       float64
+	minScanFrequency     time.Duration
+	controlInterval      time.Duration
+	configuredTargetDuty float64
+	cpuCapacityReader    cpuCapacityReader
+	cpuCapacity          atomic.Pointer[adaptiveScanCPUCapacityState]
+	capacityErrorLogged  atomic.Bool
 
 	// mu 只保护各 Runner 的局部 EWMA、最终周期和日志状态。
 	mu     sync.Mutex
@@ -144,8 +153,18 @@ type AdaptiveScanController struct {
 	logInputSnapshots func([]AdaptiveScanIntervalLog)
 }
 
+type adaptiveScanCPUCapacityState struct {
+	targetDuty     float64
+	effectiveCores float64
+	source         string
+}
+
 // NewAdaptiveScanController 创建自适应扫描控制器。
 func NewAdaptiveScanController(settings AdaptiveScanSettings) (*AdaptiveScanController, error) {
+	return newAdaptiveScanController(settings, newCPUCapacityReader())
+}
+
+func newAdaptiveScanController(settings AdaptiveScanSettings, capacityReader cpuCapacityReader) (*AdaptiveScanController, error) {
 	if settings.MinScanFrequency <= 0 {
 		return nil, fmt.Errorf("min scan frequency must be greater than 0")
 	}
@@ -156,18 +175,28 @@ func NewAdaptiveScanController(settings AdaptiveScanSettings) (*AdaptiveScanCont
 	if settings.ControlInterval <= 0 {
 		return nil, fmt.Errorf("control interval must be greater than 0")
 	}
+	if capacityReader == nil {
+		return nil, fmt.Errorf("CPU capacity reader must not be nil")
+	}
 
 	controller := &AdaptiveScanController{
-		minScanFrequency:  settings.MinScanFrequency,
-		controlInterval:   settings.ControlInterval,
-		targetDuty:        settings.ScanCPUPercent / 100,
-		inputs:            make(map[uint64]*adaptiveScanInputState),
-		now:               time.Now,
-		logIntervalChange: logAdaptiveScanIntervalChange,
-		snapshotInterval:  adaptiveScanSnapshotInterval,
-		logSnapshot:       logAdaptiveScanSnapshot,
-		logInputSnapshots: logAdaptiveScanInputSnapshots,
+		minScanFrequency:     settings.MinScanFrequency,
+		controlInterval:      settings.ControlInterval,
+		configuredTargetDuty: settings.ScanCPUPercent / 100,
+		cpuCapacityReader:    capacityReader,
+		inputs:               make(map[uint64]*adaptiveScanInputState),
+		now:                  time.Now,
+		logIntervalChange:    logAdaptiveScanIntervalChange,
+		snapshotInterval:     adaptiveScanSnapshotInterval,
+		logSnapshot:          logAdaptiveScanSnapshot,
+		logInputSnapshots:    logAdaptiveScanInputSnapshots,
 	}
+	controller.cpuCapacity.Store(&adaptiveScanCPUCapacityState{
+		targetDuty: controller.configuredTargetDuty,
+		source:     cpuCapacitySourceFallback,
+	})
+	// 容量探测失败不能阻断采集器启动；冷启动保留 PR #140 的单核预算语义。
+	_ = controller.refreshCPUCapacity()
 	controller.setMultiplier(adaptiveScanInitialMultiple)
 	return controller, nil
 }
@@ -199,7 +228,7 @@ func (c *AdaptiveScanController) NextInterval(inputID uint64, base, scanDuration
 
 	// 第一层局部控制：local = EWMA(scanDuration) / targetDuty。
 	// 例如目标占空比为 5%，一次扫描耗时 50ms，则局部周期应约为 1s。
-	localNanos := ewmaScanNanos / c.targetDuty
+	localNanos := ewmaScanNanos / c.targetDuty()
 	local := base
 	if localNanos < float64(base) {
 		local = clampDuration(time.Duration(localNanos), minimum, base)
@@ -259,6 +288,40 @@ func (c *AdaptiveScanController) removeInput(inputID uint64) {
 // Multiplier 返回当前全局扫描周期乘数。
 func (c *AdaptiveScanController) Multiplier() float64 {
 	return math.Float64frombits(c.multiplierBits.Load())
+}
+
+func (c *AdaptiveScanController) targetDuty() float64 {
+	return c.cpuCapacity.Load().targetDuty
+}
+
+func (c *AdaptiveScanController) refreshCPUCapacity() error {
+	capacity, err := c.cpuCapacityReader.Capacity()
+	if err != nil {
+		// 保留最近一次成功结果；冷启动时保留构造函数写入的 fallback。
+		return err
+	}
+
+	state := &adaptiveScanCPUCapacityState{
+		targetDuty: c.configuredTargetDuty,
+		source:     capacity.Source,
+	}
+	if state.source == "" {
+		state.source = cpuCapacitySourceFallback
+	}
+	if capacity.Limited {
+		if capacity.EffectiveCores <= 0 ||
+			math.IsNaN(capacity.EffectiveCores) || math.IsInf(capacity.EffectiveCores, 0) {
+			return fmt.Errorf("invalid effective CPU cores: %v", capacity.EffectiveCores)
+		}
+		state.effectiveCores = capacity.EffectiveCores
+		state.targetDuty *= math.Min(1, capacity.EffectiveCores)
+	}
+	c.cpuCapacity.Store(state)
+	return nil
+}
+
+func (c *AdaptiveScanController) capacityState() adaptiveScanCPUCapacityState {
+	return *c.cpuCapacity.Load()
 }
 
 // Start 启动聚合扫描占空比的周期采样。
@@ -375,7 +438,7 @@ type adaptiveScanControlModel struct {
 
 // controlModel 根据各 input 的扫描耗时 EWMA 和周期边界估算稳态聚合占空比。
 // 相比直接使用短采样窗口，模型不会在扫描周期大于 controlInterval 时因空窗口和突发窗口振荡。
-func (c *AdaptiveScanController) controlModel(current float64) adaptiveScanControlModel {
+func (c *AdaptiveScanController) controlModel(current, targetDuty float64) adaptiveScanControlModel {
 	c.mu.Lock()
 	costs := make([]adaptiveScanControlCost, 0, len(c.inputs))
 	for _, state := range c.inputs {
@@ -421,10 +484,10 @@ func (c *AdaptiveScanController) controlModel(current float64) adaptiveScanContr
 	current = clampFloat(current, 1, model.maxMultiplier)
 	model.currentDuty = dutyAt(current)
 	model.minimumDuty = dutyAt(model.maxMultiplier)
-	if dutyAt(1) <= c.targetDuty {
+	if dutyAt(1) <= targetDuty {
 		return model
 	}
-	if model.minimumDuty > c.targetDuty {
+	if model.minimumDuty > targetDuty {
 		model.desiredMultiplier = model.maxMultiplier
 		return model
 	}
@@ -434,7 +497,7 @@ func (c *AdaptiveScanController) controlModel(current float64) adaptiveScanContr
 	low, high := 1.0, model.maxMultiplier
 	for range adaptiveScanSearchIterations {
 		middle := (low + high) / 2
-		if dutyAt(middle) > c.targetDuty {
+		if dutyAt(middle) > targetDuty {
 			low = middle
 		} else {
 			high = middle
@@ -445,10 +508,19 @@ func (c *AdaptiveScanController) controlModel(current float64) adaptiveScanContr
 }
 
 func (c *AdaptiveScanController) updateMultiplier() {
+	if err := c.refreshCPUCapacity(); err != nil {
+		if c.capacityErrorLogged.CompareAndSwap(false, true) {
+			logp.L.Warnf("adaptive scan failed to refresh CPU capacity, keeping last value: %v", err)
+		}
+	} else {
+		c.capacityErrorLogged.Store(false)
+	}
+
+	targetDuty := c.targetDuty()
 	current := c.Multiplier()
-	model := c.controlModel(current)
+	model := c.controlModel(current, targetDuty)
 	c.minimumDutyBits.Store(math.Float64bits(model.minimumDuty))
-	c.budgetSaturated.Store(model.inputs > 0 && model.minimumDuty > c.targetDuty)
+	c.budgetSaturated.Store(model.inputs > 0 && model.minimumDuty > targetDuty)
 	if model.inputs == 0 {
 		c.setMultiplier(adaptiveScanInitialMultiple)
 		return
@@ -461,15 +533,15 @@ func (c *AdaptiveScanController) updateMultiplier() {
 	}
 
 	// 目标附近保留 15% 死区，避免扫描耗时的小幅波动导致周期频繁变化。
-	if model.currentDuty >= c.targetDuty*(1-adaptiveScanDeadbandRatio) &&
-		model.currentDuty <= c.targetDuty*(1+adaptiveScanDeadbandRatio) {
+	if model.currentDuty >= targetDuty*(1-adaptiveScanDeadbandRatio) &&
+		model.currentDuty <= targetDuty*(1+adaptiveScanDeadbandRatio) {
 		return
 	}
 
 	var next float64
-	if model.currentDuty > c.targetDuty {
+	if model.currentDuty > targetDuty {
 		// 严重超预算时按 8 倍、4 倍、2 倍分级快速升档，但绝不越过模型求得的目标。
-		dutyRatio := model.currentDuty / c.targetDuty
+		dutyRatio := model.currentDuty / targetDuty
 		growthRatio := adaptiveScanNormalGrowthRatio
 		switch {
 		case dutyRatio >= adaptiveScanEmergencyDutyRatio:
@@ -517,6 +589,7 @@ func (c *AdaptiveScanController) maybeLogIntervalChange(
 		return
 	}
 
+	capacity := c.capacityState()
 	c.logIntervalChange(AdaptiveScanIntervalLog{
 		RunnerID:          runnerID,
 		InputID:           metadata.InputID,
@@ -528,6 +601,9 @@ func (c *AdaptiveScanController) maybeLogIntervalChange(
 		EffectiveInterval: effective,
 		Multiplier:        c.Multiplier(),
 		ScanDuration:      scanDuration,
+		TargetDuty:        capacity.targetDuty,
+		EffectiveCores:    capacity.effectiveCores,
+		CPUCapacitySource: capacity.source,
 	})
 }
 
@@ -538,12 +614,16 @@ func (c *AdaptiveScanController) snapshot() AdaptiveScanSnapshot {
 		state    adaptiveScanInputState
 	}
 
+	capacity := c.cpuCapacity.Load()
 	snapshot := AdaptiveScanSnapshot{
-		Multiplier:          c.Multiplier(),
-		ScanDuty:            math.Float64frombits(c.lastDutyBits.Load()),
-		TargetDuty:          c.targetDuty,
-		MinimumPossibleDuty: math.Float64frombits(c.minimumDutyBits.Load()),
-		BudgetSaturated:     c.budgetSaturated.Load(),
+		Multiplier:           c.Multiplier(),
+		ScanDuty:             math.Float64frombits(c.lastDutyBits.Load()),
+		ConfiguredTargetDuty: c.configuredTargetDuty,
+		TargetDuty:           capacity.targetDuty,
+		EffectiveCores:       capacity.effectiveCores,
+		CPUCapacitySource:    capacity.source,
+		MinimumPossibleDuty:  math.Float64frombits(c.minimumDutyBits.Load()),
+		BudgetSaturated:      c.budgetSaturated.Load(),
 	}
 	var candidates []candidate
 
@@ -628,6 +708,7 @@ func (c *AdaptiveScanController) inputSnapshots() []AdaptiveScanIntervalLog {
 	sort.Slice(states, func(i, j int) bool {
 		return states[i].runnerID < states[j].runnerID
 	})
+	capacity := c.capacityState()
 	records := make([]AdaptiveScanIntervalLog, 0, len(states))
 	for _, item := range states {
 		record := AdaptiveScanIntervalLog{
@@ -637,6 +718,9 @@ func (c *AdaptiveScanController) inputSnapshots() []AdaptiveScanIntervalLog {
 			EffectiveInterval: item.state.effectiveInterval,
 			Multiplier:        c.Multiplier(),
 			ScanDuration:      item.state.lastScanDuration,
+			TargetDuty:        capacity.targetDuty,
+			EffectiveCores:    capacity.effectiveCores,
+			CPUCapacitySource: capacity.source,
 		}
 		if metadata, ok := adaptiveScanInputMetadata(item.runnerID); ok {
 			record.InputID = metadata.InputID
@@ -683,7 +767,8 @@ func adaptiveScanIntervalBucket(interval, base time.Duration) int {
 func logAdaptiveScanIntervalChange(record AdaptiveScanIntervalLog) {
 	logp.L.Infof(
 		"adaptive scan interval changed: runner_id=%d input_id=%s task_ids=%v data_ids=%v paths=%v "+
-			"base=%s requested_interval=%s effective_interval=%s multiplier=%.3f scan_duration=%s",
+			"base=%s requested_interval=%s effective_interval=%s multiplier=%.3f scan_duration=%s "+
+			"target_duty=%.4f effective_cores=%.3f cpu_capacity_source=%s",
 		record.RunnerID,
 		record.InputID,
 		record.TaskIDs,
@@ -694,19 +779,26 @@ func logAdaptiveScanIntervalChange(record AdaptiveScanIntervalLog) {
 		record.EffectiveInterval,
 		record.Multiplier,
 		record.ScanDuration,
+		record.TargetDuty,
+		record.EffectiveCores,
+		record.CPUCapacitySource,
 	)
 }
 
 func logAdaptiveScanSnapshot(snapshot AdaptiveScanSnapshot) {
 	logp.L.Debugf(
 		"adaptive scan snapshot: inputs=%d shortened=%d multiplier=%.3f scan_duty=%.4f "+
-			"target_duty=%.4f minimum_possible_duty=%.4f budget_saturated=%t "+
+			"configured_target_duty=%.4f target_duty=%.4f effective_cores=%.3f cpu_capacity_source=%s "+
+			"minimum_possible_duty=%.4f budget_saturated=%t "+
 			"intervals=%+v slowest_inputs=%+v",
 		snapshot.Inputs,
 		snapshot.Shortened,
 		snapshot.Multiplier,
 		snapshot.ScanDuty,
+		snapshot.ConfiguredTargetDuty,
 		snapshot.TargetDuty,
+		snapshot.EffectiveCores,
+		snapshot.CPUCapacitySource,
 		snapshot.MinimumPossibleDuty,
 		snapshot.BudgetSaturated,
 		snapshot.Intervals,
@@ -718,7 +810,8 @@ func logAdaptiveScanInputSnapshots(records []AdaptiveScanIntervalLog) {
 	for _, record := range records {
 		logp.L.Debugf(
 			"adaptive scan input snapshot: runner_id=%d input_id=%s task_ids=%v data_ids=%v paths=%v "+
-				"base=%s requested_interval=%s effective_interval=%s multiplier=%.3f scan_duration=%s",
+				"base=%s requested_interval=%s effective_interval=%s multiplier=%.3f scan_duration=%s "+
+				"target_duty=%.4f effective_cores=%.3f cpu_capacity_source=%s",
 			record.RunnerID,
 			record.InputID,
 			record.TaskIDs,
@@ -729,6 +822,9 @@ func logAdaptiveScanInputSnapshots(records []AdaptiveScanIntervalLog) {
 			record.EffectiveInterval,
 			record.Multiplier,
 			record.ScanDuration,
+			record.TargetDuty,
+			record.EffectiveCores,
+			record.CPUCapacitySource,
 		)
 	}
 }

--- a/utils/adaptive_scan_test.go
+++ b/utils/adaptive_scan_test.go
@@ -13,12 +13,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type staticCPUCapacityReader struct {
+	capacity cpuCapacity
+	err      error
+}
+
+func (r staticCPUCapacityReader) Capacity() (cpuCapacity, error) {
+	return r.capacity, r.err
+}
+
 func newTestAdaptiveScanController(t *testing.T) *AdaptiveScanController {
 	t.Helper()
-	controller, err := NewAdaptiveScanController(AdaptiveScanSettings{
+	return newTestAdaptiveScanControllerWithSettings(t, AdaptiveScanSettings{
 		MinScanFrequency: 500 * time.Millisecond,
 		ScanCPUPercent:   5,
 		ControlInterval:  3 * time.Second,
+	})
+}
+
+func newTestAdaptiveScanControllerWithSettings(
+	t *testing.T,
+	settings AdaptiveScanSettings,
+) *AdaptiveScanController {
+	t.Helper()
+	controller, err := newAdaptiveScanController(settings, staticCPUCapacityReader{
+		capacity: cpuCapacity{Source: cpuCapacitySourceUnlimited},
 	})
 	assert.NoError(t, err)
 	controller.logIntervalChange = func(AdaptiveScanIntervalLog) {}
@@ -86,12 +105,11 @@ func TestAdaptiveScanGovernorDeadband(t *testing.T) {
 }
 
 func TestAdaptiveScanGovernorConvergesWithOneHundredInputs(t *testing.T) {
-	controller, err := NewAdaptiveScanController(AdaptiveScanSettings{
+	controller := newTestAdaptiveScanControllerWithSettings(t, AdaptiveScanSettings{
 		MinScanFrequency: time.Second,
 		ScanCPUPercent:   5,
 		ControlInterval:  3 * time.Second,
 	})
-	assert.NoError(t, err)
 
 	const inputs = 100
 	base := 300 * time.Second
@@ -107,16 +125,46 @@ func TestAdaptiveScanGovernorConvergesWithOneHundredInputs(t *testing.T) {
 	assert.InDelta(t, 20, controller.Multiplier(), 0.1)
 	interval := controller.NextInterval(1, base, scanDuration)
 	assert.InDelta(t, 20*time.Second, interval, float64(time.Millisecond))
-	assert.InDelta(t, controller.targetDuty, float64(inputs)*float64(scanDuration)/float64(interval), 0.0001)
+	assert.InDelta(t, controller.targetDuty(), float64(inputs)*float64(scanDuration)/float64(interval), 0.0001)
+}
+
+func TestAdaptiveScanGovernorScalesTargetForSubCoreQuota(t *testing.T) {
+	controller, err := newAdaptiveScanController(AdaptiveScanSettings{
+		MinScanFrequency: time.Second,
+		ScanCPUPercent:   5,
+		ControlInterval:  3 * time.Second,
+	}, staticCPUCapacityReader{
+		capacity: cpuCapacity{
+			EffectiveCores: 0.5,
+			Source:         cpuCapacitySourceCgroupV2Quota,
+			Limited:        true,
+		},
+	})
+	assert.NoError(t, err)
+
+	const inputs = 100
+	base := 300 * time.Second
+	scanDuration := 10 * time.Millisecond
+	for runnerID := uint64(1); runnerID <= inputs; runnerID++ {
+		nextAndObserve(controller, runnerID, base, scanDuration)
+	}
+	for range 3 {
+		controller.updateMultiplier()
+	}
+
+	assert.InDelta(t, 0.025, controller.targetDuty(), 0.0001)
+	assert.InDelta(t, 40, controller.Multiplier(), 0.1)
+	interval := controller.NextInterval(1, base, scanDuration)
+	assert.InDelta(t, 40*time.Second, interval, float64(time.Millisecond))
+	assert.InDelta(t, controller.targetDuty(), float64(inputs)*float64(scanDuration)/float64(interval), 0.0001)
 }
 
 func TestAdaptiveScanGovernorConvergesAboveLegacyCap(t *testing.T) {
-	controller, err := NewAdaptiveScanController(AdaptiveScanSettings{
+	controller := newTestAdaptiveScanControllerWithSettings(t, AdaptiveScanSettings{
 		MinScanFrequency: time.Second,
 		ScanCPUPercent:   5,
 		ControlInterval:  3 * time.Second,
 	})
-	assert.NoError(t, err)
 
 	const inputs = 1000
 	base := 300 * time.Second
@@ -133,16 +181,15 @@ func TestAdaptiveScanGovernorConvergesAboveLegacyCap(t *testing.T) {
 	assert.Greater(t, controller.Multiplier(), float64(64))
 	interval := controller.NextInterval(1, base, scanDuration)
 	assert.InDelta(t, 200*time.Second, interval, float64(time.Millisecond))
-	assert.InDelta(t, controller.targetDuty, float64(inputs)*float64(scanDuration)/float64(interval), 0.0001)
+	assert.InDelta(t, controller.targetDuty(), float64(inputs)*float64(scanDuration)/float64(interval), 0.0001)
 }
 
 func TestAdaptiveScanGovernorStopsAtDynamicLimitWhenBudgetIsImpossible(t *testing.T) {
-	controller, err := NewAdaptiveScanController(AdaptiveScanSettings{
+	controller := newTestAdaptiveScanControllerWithSettings(t, AdaptiveScanSettings{
 		MinScanFrequency: time.Second,
 		ScanCPUPercent:   5,
 		ControlInterval:  3 * time.Second,
 	})
-	assert.NoError(t, err)
 
 	const inputs = 1000
 	base := 100 * time.Second
@@ -180,12 +227,11 @@ func TestAdaptiveScanGovernorResetsWithoutActiveInputs(t *testing.T) {
 }
 
 func TestAdaptiveScanGovernorRecoversTowardOne(t *testing.T) {
-	controller, err := NewAdaptiveScanController(AdaptiveScanSettings{
+	controller := newTestAdaptiveScanControllerWithSettings(t, AdaptiveScanSettings{
 		MinScanFrequency: time.Second,
 		ScanCPUPercent:   5,
 		ControlInterval:  3 * time.Second,
 	})
-	assert.NoError(t, err)
 	for runnerID := uint64(1); runnerID <= 100; runnerID++ {
 		nextAndObserve(controller, runnerID, 300*time.Second, 10*time.Millisecond)
 	}
@@ -227,12 +273,11 @@ func TestAdaptiveScanGovernorSmoothsAggregateDuty(t *testing.T) {
 }
 
 func TestAdaptiveScanGovernorStartStopIsIdempotent(t *testing.T) {
-	controller, err := NewAdaptiveScanController(AdaptiveScanSettings{
+	controller := newTestAdaptiveScanControllerWithSettings(t, AdaptiveScanSettings{
 		MinScanFrequency: 500 * time.Millisecond,
 		ScanCPUPercent:   5,
 		ControlInterval:  10 * time.Millisecond,
 	})
-	assert.NoError(t, err)
 
 	for runnerID := uint64(1); runnerID <= 100; runnerID++ {
 		controller.NextInterval(runnerID, 300*time.Second, 10*time.Millisecond)
@@ -325,6 +370,8 @@ func TestAdaptiveScanControllerLogsMeaningfulIntervalChanges(t *testing.T) {
 	assert.Equal(t, []int{1001}, records[0].DataIDs)
 	assert.Equal(t, 500*time.Millisecond, records[0].RequestedInterval)
 	assert.Equal(t, 500*time.Millisecond, records[0].EffectiveInterval)
+	assert.InDelta(t, 0.05, records[0].TargetDuty, 0.0001)
+	assert.Equal(t, cpuCapacitySourceUnlimited, records[0].CPUCapacitySource)
 
 	now = now.Add(10 * time.Second)
 	nextAndObserve(controller, runnerID, 10*time.Second, 100*time.Millisecond)
@@ -429,6 +476,10 @@ func TestAdaptiveScanControllerBuildsBoundedAggregateSnapshot(t *testing.T) {
 	assert.Equal(t, 1, snapshot.Intervals.UpTo2Seconds)
 	assert.Equal(t, 1, snapshot.Intervals.AtBase)
 	assert.InDelta(t, 0.03, snapshot.ScanDuty, 0.0001)
+	assert.InDelta(t, 0.05, snapshot.ConfiguredTargetDuty, 0.0001)
+	assert.InDelta(t, 0.05, snapshot.TargetDuty, 0.0001)
+	assert.Zero(t, snapshot.EffectiveCores)
+	assert.Equal(t, cpuCapacitySourceUnlimited, snapshot.CPUCapacitySource)
 	assert.Len(t, snapshot.SlowestInputs, 3)
 	assert.Equal(t, runnerIDs[2], snapshot.SlowestInputs[0].RunnerID)
 

--- a/utils/cpu_capacity.go
+++ b/utils/cpu_capacity.go
@@ -1,0 +1,520 @@
+// Tencent is pleased to support the open source community by making bkunifylogbeat 蓝鲸日志采集器 available.
+//
+// Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License.
+
+package utils
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	defaultCgroupRoot     = "/sys/fs/cgroup"
+	defaultProcRoot       = "/proc"
+	defaultCPUMaxPeriodUS = 100000
+
+	cpuCapacitySourceFallback      = "fallback"
+	cpuCapacitySourceUnlimited     = "unlimited"
+	cpuCapacitySourceNonLinux      = "non_linux"
+	cpuCapacitySourceCgroupV1Quota = "cgroup_v1_quota"
+	cpuCapacitySourceCgroupV1Set   = "cgroup_v1_cpuset"
+	cpuCapacitySourceCgroupV2Quota = "cgroup_v2_quota"
+	cpuCapacitySourceCgroupV2Set   = "cgroup_v2_cpuset"
+)
+
+// cpuCapacity 描述当前进程可使用的有效 CPU 容量。
+// Limited=false 表示未发现 cgroup quota 或 cpuset 硬限制，调用方应保留原有单核预算语义。
+type cpuCapacity struct {
+	EffectiveCores float64
+	Source         string
+	Limited        bool
+}
+
+type cpuCapacityReader interface {
+	Capacity() (cpuCapacity, error)
+}
+
+type cgroupCPUCapacityReader struct {
+	cgroupRoot string
+	procRoot   string
+	layout     cgroupLayout
+	layoutErr  error
+}
+
+type cgroupLayout struct {
+	v2Mount          *cgroupMount
+	controllerMounts map[string]cgroupMount
+	controllerPaths  map[string]string
+}
+
+type cgroupMount struct {
+	root        string
+	mountPoint  string
+	fsType      string
+	controllers []string
+}
+
+type cpuCapacityCandidate struct {
+	cores  float64
+	source string
+}
+
+func newCgroupCPUCapacityReader() *cgroupCPUCapacityReader {
+	return newCgroupCPUCapacityReaderWithRoots(defaultCgroupRoot, defaultProcRoot)
+}
+
+func newCgroupCPUCapacityReaderWithRoots(cgroupRoot, procRoot string) *cgroupCPUCapacityReader {
+	reader := &cgroupCPUCapacityReader{
+		cgroupRoot: cgroupRoot,
+		procRoot:   procRoot,
+	}
+	reader.layout, reader.layoutErr = reader.loadLayout()
+	return reader
+}
+
+// Capacity 读取当前进程所在 cgroup 的 quota 与 cpuset，并取所有硬限制中的最小值。
+// quota 文件每次调用都会重新读取，从而支持运行时调整容器 CPU limit。
+func (r *cgroupCPUCapacityReader) Capacity() (cpuCapacity, error) {
+	if r.layoutErr != nil {
+		return cpuCapacity{}, r.layoutErr
+	}
+
+	var candidates []cpuCapacityCandidate
+	var readErrors []error
+	seen := false
+
+	if r.layout.v2Mount != nil {
+		cgroupPath, pathFound := r.layout.controllerPaths[""]
+		dirs, resolved := hierarchyDirs(*r.layout.v2Mount, cgroupPath)
+		if pathFound && resolved {
+			cores, limited, readable, err := readV2Quota(dirs)
+			if err != nil {
+				readErrors = append(readErrors, err)
+			}
+			if readable {
+				seen = true
+			}
+			if limited {
+				candidates = append(candidates, cpuCapacityCandidate{
+					cores:  cores,
+					source: cpuCapacitySourceCgroupV2Quota,
+				})
+			}
+
+			cores, limited, readable, err = readCPUSet(dirs, []string{"cpuset.cpus.effective", "cpuset.cpus"})
+			if err != nil {
+				readErrors = append(readErrors, err)
+			}
+			if readable {
+				seen = true
+			}
+			if limited {
+				candidates = append(candidates, cpuCapacityCandidate{
+					cores:  cores,
+					source: cpuCapacitySourceCgroupV2Set,
+				})
+			}
+		}
+	}
+
+	if mount, ok := r.layout.controllerMounts["cpu"]; ok {
+		cgroupPath, pathFound := r.layout.controllerPaths["cpu"]
+		if dirs, resolved := hierarchyDirs(mount, cgroupPath); pathFound && resolved {
+			cores, limited, readable, err := readV1Quota(dirs)
+			if err != nil {
+				readErrors = append(readErrors, err)
+			}
+			if readable {
+				seen = true
+			}
+			if limited {
+				candidates = append(candidates, cpuCapacityCandidate{
+					cores:  cores,
+					source: cpuCapacitySourceCgroupV1Quota,
+				})
+			}
+		}
+	}
+	if mount, ok := r.layout.controllerMounts["cpuset"]; ok {
+		cgroupPath, pathFound := r.layout.controllerPaths["cpuset"]
+		if dirs, resolved := hierarchyDirs(mount, cgroupPath); pathFound && resolved {
+			cores, limited, readable, err := readCPUSet(dirs, []string{"cpuset.cpus.effective", "cpuset.cpus"})
+			if err != nil {
+				readErrors = append(readErrors, err)
+			}
+			if readable {
+				seen = true
+			}
+			if limited {
+				candidates = append(candidates, cpuCapacityCandidate{
+					cores:  cores,
+					source: cpuCapacitySourceCgroupV1Set,
+				})
+			}
+		}
+	}
+
+	if len(readErrors) > 0 {
+		return cpuCapacity{}, errors.Join(readErrors...)
+	}
+	if len(candidates) == 0 {
+		if seen {
+			return cpuCapacity{Source: cpuCapacitySourceUnlimited}, nil
+		}
+		return cpuCapacity{}, errors.New("failed to read cgroup CPU capacity")
+	}
+
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return candidates[i].cores < candidates[j].cores
+	})
+	return cpuCapacity{
+		EffectiveCores: candidates[0].cores,
+		Source:         candidates[0].source,
+		Limited:        true,
+	}, nil
+}
+
+func readV2Quota(dirs []string) (cores float64, limited, readable bool, resultErr error) {
+	minQuota := 0.0
+	for _, dir := range dirs {
+		filename := filepath.Join(dir, "cpu.max")
+		data, err := os.ReadFile(filename)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return 0, false, readable, fmt.Errorf("read %s: %w", filename, err)
+			}
+			continue
+		}
+		readable = true
+		quota, quotaLimited, err := parseCPUMaxValue(string(data))
+		if err != nil {
+			return 0, false, true, fmt.Errorf("parse %s: %w", filename, err)
+		}
+		if quotaLimited && (minQuota == 0 || quota < minQuota) {
+			minQuota = quota
+		}
+	}
+	return minQuota, minQuota > 0, readable, nil
+}
+
+func readV1Quota(dirs []string) (cores float64, limited, readable bool, resultErr error) {
+	minQuota := 0.0
+	for _, dir := range dirs {
+		quotaData, quotaErr := os.ReadFile(filepath.Join(dir, "cpu.cfs_quota_us"))
+		periodData, periodErr := os.ReadFile(filepath.Join(dir, "cpu.cfs_period_us"))
+		if quotaErr != nil || periodErr != nil {
+			if quotaErr == nil || periodErr == nil ||
+				(quotaErr != nil && !errors.Is(quotaErr, os.ErrNotExist)) ||
+				(periodErr != nil && !errors.Is(periodErr, os.ErrNotExist)) {
+				return 0, false, readable, fmt.Errorf(
+					"read v1 CPU quota in %s: quota=%v period=%v",
+					dir, quotaErr, periodErr,
+				)
+			}
+			continue
+		}
+		readable = true
+
+		quota, quotaErr := strconv.ParseInt(strings.TrimSpace(string(quotaData)), 10, 64)
+		period, periodErr := strconv.ParseInt(strings.TrimSpace(string(periodData)), 10, 64)
+		if quotaErr != nil || periodErr != nil || period <= 0 || quota == 0 || quota < -1 {
+			return 0, false, true, fmt.Errorf("parse v1 CPU quota in %s", dir)
+		}
+		if quota == -1 {
+			continue
+		}
+		value := float64(quota) / float64(period)
+		if minQuota == 0 || value < minQuota {
+			minQuota = value
+		}
+	}
+	return minQuota, minQuota > 0, readable, nil
+}
+
+func parseCPUMax(value string) (float64, bool) {
+	cores, limited, err := parseCPUMaxValue(value)
+	return cores, limited && err == nil
+}
+
+func parseCPUMaxValue(value string) (float64, bool, error) {
+	fields := strings.Fields(value)
+	if len(fields) == 0 || len(fields) > 2 {
+		return 0, false, fmt.Errorf("expected quota and optional period, got %q", value)
+	}
+
+	period := float64(defaultCPUMaxPeriodUS)
+	if len(fields) == 2 {
+		var periodErr error
+		period, periodErr = strconv.ParseFloat(fields[1], 64)
+		if periodErr != nil {
+			return 0, false, fmt.Errorf("invalid period %q", fields[1])
+		}
+	}
+	if period <= 0 || math.IsNaN(period) || math.IsInf(period, 0) {
+		return 0, false, fmt.Errorf("invalid period %q", fields[len(fields)-1])
+	}
+	if fields[0] == "max" {
+		return 0, false, nil
+	}
+	quota, quotaErr := strconv.ParseFloat(fields[0], 64)
+	if quotaErr != nil || quota <= 0 || math.IsNaN(quota) || math.IsInf(quota, 0) {
+		return 0, false, fmt.Errorf("invalid quota %q", fields[0])
+	}
+	return quota / period, true, nil
+}
+
+func readCPUSet(dirs []string, filenames []string) (cores float64, limited, readable bool, resultErr error) {
+	for _, dir := range dirs {
+		for _, filename := range filenames {
+			fullPath := filepath.Join(dir, filename)
+			data, err := os.ReadFile(fullPath)
+			if err != nil {
+				if !errors.Is(err, os.ErrNotExist) {
+					return 0, false, readable, fmt.Errorf("read %s: %w", fullPath, err)
+				}
+				continue
+			}
+			readable = true
+			count, err := parseCPUSet(string(data))
+			if err != nil {
+				return 0, false, true, fmt.Errorf("parse %s: %w", fullPath, err)
+			}
+			if count > 0 {
+				return float64(count), true, true, nil
+			}
+		}
+	}
+	return 0, false, readable, nil
+}
+
+func parseCPUSet(value string) (int, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, nil
+	}
+
+	total := 0
+	for _, part := range strings.Split(value, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		bounds := strings.Split(part, "-")
+		if len(bounds) == 1 {
+			if _, err := strconv.Atoi(bounds[0]); err != nil {
+				return 0, fmt.Errorf("invalid CPU %q", part)
+			}
+			total++
+			continue
+		}
+		if len(bounds) != 2 {
+			return 0, fmt.Errorf("invalid CPU range %q", part)
+		}
+		start, startErr := strconv.Atoi(bounds[0])
+		end, endErr := strconv.Atoi(bounds[1])
+		if startErr != nil || endErr != nil || end < start {
+			return 0, fmt.Errorf("invalid CPU range %q", part)
+		}
+		total += end - start + 1
+	}
+	return total, nil
+}
+
+func hierarchyDirs(mount cgroupMount, cgroupPath string) ([]string, bool) {
+	leaf, ok := resolveCgroupPath(mount, cgroupPath)
+	if !ok {
+		return nil, false
+	}
+
+	mountPoint := filepath.Clean(mount.mountPoint)
+	current := filepath.Clean(leaf)
+	var dirs []string
+	for {
+		dirs = append(dirs, current)
+		if current == mountPoint {
+			break
+		}
+		parent := filepath.Dir(current)
+		if parent == current || !pathWithinMount(parent, mountPoint) {
+			return nil, false
+		}
+		current = parent
+	}
+	return dirs, true
+}
+
+func resolveCgroupPath(mount cgroupMount, cgroupPath string) (string, bool) {
+	mountRoot := cleanCgroupPath(mount.root)
+	processPath := cleanCgroupPath(cgroupPath)
+
+	var relative string
+	switch {
+	case processPath == "/":
+		// 在 cgroup namespace 中，当前进程通常看到自身所在 cgroup 为 "/"；
+		// mountinfo.root 已经指向真实宿主层级，因此 mountPoint 本身就是 leaf。
+		relative = ""
+	case mountRoot == "/":
+		relative = strings.TrimPrefix(processPath, "/")
+	case processPath == mountRoot:
+		relative = ""
+	case strings.HasPrefix(processPath, mountRoot+"/"):
+		relative = strings.TrimPrefix(processPath, mountRoot+"/")
+	default:
+		return "", false
+	}
+
+	resolved := filepath.Join(filepath.Clean(mount.mountPoint), filepath.FromSlash(relative))
+	if !pathWithinMount(resolved, filepath.Clean(mount.mountPoint)) {
+		return "", false
+	}
+	return resolved, true
+}
+
+func cleanCgroupPath(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "/"
+	}
+	return path.Clean("/" + strings.TrimPrefix(value, "/"))
+}
+
+func pathWithinMount(candidate, mountPoint string) bool {
+	candidate = filepath.Clean(candidate)
+	mountPoint = filepath.Clean(mountPoint)
+	return candidate == mountPoint || strings.HasPrefix(candidate, mountPoint+string(os.PathSeparator))
+}
+
+func (r *cgroupCPUCapacityReader) loadLayout() (cgroupLayout, error) {
+	controllerPaths, err := parseProcCgroup(filepath.Join(r.procRoot, "self", "cgroup"))
+	if err != nil {
+		return cgroupLayout{}, fmt.Errorf("parse proc self cgroup: %w", err)
+	}
+	mounts, err := parseMountInfo(filepath.Join(r.procRoot, "self", "mountinfo"))
+	if err != nil {
+		return cgroupLayout{}, fmt.Errorf("parse proc self mountinfo: %w", err)
+	}
+
+	layout := cgroupLayout{
+		controllerMounts: make(map[string]cgroupMount),
+		controllerPaths:  controllerPaths,
+	}
+	for _, mount := range mounts {
+		mount.mountPoint = r.rebaseMountPoint(mount.mountPoint)
+		switch mount.fsType {
+		case "cgroup2":
+			current := mount
+			layout.v2Mount = &current
+		case "cgroup":
+			for _, controller := range mount.controllers {
+				layout.controllerMounts[controller] = mount
+			}
+		}
+	}
+	if layout.v2Mount == nil && len(layout.controllerMounts) == 0 {
+		return cgroupLayout{}, errors.New("no cgroup mounts found")
+	}
+	return layout, nil
+}
+
+// rebaseMountPoint 只用于注入临时 cgroupRoot 的测试；生产默认根不会改写 mountinfo。
+func (r *cgroupCPUCapacityReader) rebaseMountPoint(mountPoint string) string {
+	if r.cgroupRoot == defaultCgroupRoot {
+		return mountPoint
+	}
+	relative, err := filepath.Rel(defaultCgroupRoot, mountPoint)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(os.PathSeparator)) {
+		return mountPoint
+	}
+	return filepath.Join(r.cgroupRoot, relative)
+}
+
+func parseMountInfo(filename string) ([]cgroupMount, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var mounts []cgroupMount
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		separator := -1
+		for index, field := range fields {
+			if field == "-" {
+				separator = index
+				break
+			}
+		}
+		if separator < 0 || separator+3 >= len(fields) || len(fields) < 6 {
+			continue
+		}
+
+		fsType := fields[separator+1]
+		if fsType != "cgroup" && fsType != "cgroup2" {
+			continue
+		}
+		mount := cgroupMount{
+			root:       unescapeMountInfoPath(fields[3]),
+			mountPoint: unescapeMountInfoPath(fields[4]),
+			fsType:     fsType,
+		}
+		if fsType == "cgroup" {
+			mount.controllers = strings.Split(fields[separator+3], ",")
+		}
+		mounts = append(mounts, mount)
+	}
+	return mounts, nil
+}
+
+func unescapeMountInfoPath(value string) string {
+	replacer := strings.NewReplacer(
+		`\040`, " ",
+		`\011`, "\t",
+		`\012`, "\n",
+		`\134`, `\`,
+	)
+	return replacer.Replace(value)
+}
+
+func parseProcCgroup(filename string) (map[string]string, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	paths := make(map[string]string)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 3)
+		if len(parts) != 3 || strings.TrimSpace(parts[2]) == "" {
+			return nil, fmt.Errorf("invalid cgroup entry %q", line)
+		}
+		for _, controller := range strings.Split(parts[1], ",") {
+			paths[controller] = parts[2]
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if len(paths) == 0 {
+		return nil, errors.New("no cgroup entries found")
+	}
+	return paths, nil
+}

--- a/utils/cpu_capacity_linux.go
+++ b/utils/cpu_capacity_linux.go
@@ -1,0 +1,13 @@
+// Tencent is pleased to support the open source community by making bkunifylogbeat 蓝鲸日志采集器 available.
+//
+// Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build linux
+// +build linux
+
+package utils
+
+func newCPUCapacityReader() cpuCapacityReader {
+	return newCgroupCPUCapacityReader()
+}

--- a/utils/cpu_capacity_other.go
+++ b/utils/cpu_capacity_other.go
@@ -1,0 +1,19 @@
+// Tencent is pleased to support the open source community by making bkunifylogbeat 蓝鲸日志采集器 available.
+//
+// Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build !linux
+// +build !linux
+
+package utils
+
+type fallbackCPUCapacityReader struct{}
+
+func (fallbackCPUCapacityReader) Capacity() (cpuCapacity, error) {
+	return cpuCapacity{Source: cpuCapacitySourceNonLinux}, nil
+}
+
+func newCPUCapacityReader() cpuCapacityReader {
+	return fallbackCPUCapacityReader{}
+}

--- a/utils/cpu_capacity_other_test.go
+++ b/utils/cpu_capacity_other_test.go
@@ -1,0 +1,32 @@
+// Tencent is pleased to support the open source community by making bkunifylogbeat 蓝鲸日志采集器 available.
+//
+// Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build !linux
+// +build !linux
+
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdaptiveScanNonLinuxFallbackPreservesSingleCoreBudget(t *testing.T) {
+	controller, err := NewAdaptiveScanController(AdaptiveScanSettings{
+		MinScanFrequency: 100 * time.Millisecond,
+		ScanCPUPercent:   5,
+		ControlInterval:  time.Second,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, time.Second, controller.NextInterval(1, 30*time.Second, 50*time.Millisecond))
+	snapshot := controller.snapshot()
+	assert.InDelta(t, 0.05, snapshot.TargetDuty, 0.0001)
+	assert.Zero(t, snapshot.EffectiveCores)
+	assert.Equal(t, cpuCapacitySourceNonLinux, snapshot.CPUCapacitySource)
+}

--- a/utils/cpu_capacity_test.go
+++ b/utils/cpu_capacity_test.go
@@ -1,0 +1,301 @@
+// Tencent is pleased to support the open source community by making bkunifylogbeat 蓝鲸日志采集器 available.
+//
+// Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build !windows
+// +build !windows
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdaptiveScanCgroupBudgetEndToEnd(t *testing.T) {
+	tests := []struct {
+		version      int
+		quotaCores   float64
+		wantTarget   float64
+		wantInterval time.Duration
+		wantSource   string
+	}{
+		{version: 1, quotaCores: 0.1, wantTarget: 0.005, wantInterval: 10 * time.Second, wantSource: cpuCapacitySourceCgroupV1Quota},
+		{version: 1, quotaCores: 0.5, wantTarget: 0.025, wantInterval: 2 * time.Second, wantSource: cpuCapacitySourceCgroupV1Quota},
+		{version: 1, quotaCores: 1, wantTarget: 0.05, wantInterval: time.Second, wantSource: cpuCapacitySourceCgroupV1Quota},
+		{version: 1, quotaCores: 2, wantTarget: 0.05, wantInterval: time.Second, wantSource: cpuCapacitySourceCgroupV1Quota},
+		{version: 2, quotaCores: 0.1, wantTarget: 0.005, wantInterval: 10 * time.Second, wantSource: cpuCapacitySourceCgroupV2Quota},
+		{version: 2, quotaCores: 0.5, wantTarget: 0.025, wantInterval: 2 * time.Second, wantSource: cpuCapacitySourceCgroupV2Quota},
+		{version: 2, quotaCores: 1, wantTarget: 0.05, wantInterval: time.Second, wantSource: cpuCapacitySourceCgroupV2Quota},
+		{version: 2, quotaCores: 2, wantTarget: 0.05, wantInterval: time.Second, wantSource: cpuCapacitySourceCgroupV2Quota},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("v%d_%.1f_cores", tt.version, tt.quotaCores), func(t *testing.T) {
+			reader, _ := newTestCgroupCapacityReader(t, tt.version, tt.quotaCores)
+			controller, err := newAdaptiveScanController(AdaptiveScanSettings{
+				MinScanFrequency: 100 * time.Millisecond,
+				ScanCPUPercent:   5,
+				ControlInterval:  time.Second,
+			}, reader)
+			require.NoError(t, err)
+
+			interval := controller.NextInterval(1, 30*time.Second, 50*time.Millisecond)
+			snapshot := controller.snapshot()
+
+			assert.InDelta(t, tt.wantInterval, interval, float64(time.Nanosecond))
+			assert.InDelta(t, tt.wantTarget, snapshot.TargetDuty, 0.00001)
+			assert.InDelta(t, tt.quotaCores, snapshot.EffectiveCores, 0.00001)
+			assert.Equal(t, tt.wantSource, snapshot.CPUCapacitySource)
+		})
+	}
+}
+
+func TestCgroupCPUCapacityUsesTightestV2HierarchyLimit(t *testing.T) {
+	cgroupRoot, procRoot := newTestCgroupRoots(t)
+	leaf := filepath.Join(cgroupRoot, "kubepods", "pod1", "container1")
+	pod := filepath.Dir(leaf)
+	parent := filepath.Dir(pod)
+
+	writeCgroupTestFile(t, filepath.Join(procRoot, "self", "cgroup"), "0::/kubepods/pod1/container1\n")
+	writeCgroupTestFile(t, filepath.Join(procRoot, "self", "mountinfo"),
+		"36 25 0:32 / /sys/fs/cgroup rw - cgroup2 cgroup rw\n")
+	writeCgroupTestFile(t, filepath.Join(leaf, "cpu.max"), "max 100000\n")
+	writeCgroupTestFile(t, filepath.Join(pod, "cpu.max"), "200000 100000\n")
+	writeCgroupTestFile(t, filepath.Join(parent, "cpu.max"), "50000 100000\n")
+	writeCgroupTestFile(t, filepath.Join(cgroupRoot, "cpu.max"), "100000 100000\n")
+	writeCgroupTestFile(t, filepath.Join(leaf, "cpuset.cpus.effective"), "0-3\n")
+
+	capacity, err := newCgroupCPUCapacityReaderWithRoots(cgroupRoot, procRoot).Capacity()
+
+	require.NoError(t, err)
+	assert.True(t, capacity.Limited)
+	assert.InDelta(t, 0.5, capacity.EffectiveCores, 0.0001)
+	assert.Equal(t, cpuCapacitySourceCgroupV2Quota, capacity.Source)
+}
+
+func TestCgroupCPUCapacityUsesTightestV1HierarchyLimit(t *testing.T) {
+	cgroupRoot, procRoot := newTestCgroupRoots(t)
+	cpuMount := filepath.Join(cgroupRoot, "cpu")
+	cpusetMount := filepath.Join(cgroupRoot, "cpuset")
+	leaf := filepath.Join(cpuMount, "workloads", "collector")
+	parent := filepath.Dir(leaf)
+
+	writeCgroupTestFile(t, filepath.Join(procRoot, "self", "cgroup"),
+		"2:cpu,cpuacct:/workloads/collector\n3:cpuset:/workloads/collector\n")
+	writeCgroupTestFile(t, filepath.Join(procRoot, "self", "mountinfo"),
+		"36 25 0:32 / /sys/fs/cgroup/cpu rw - cgroup cgroup rw,cpu,cpuacct\n"+
+			"37 25 0:33 / /sys/fs/cgroup/cpuset rw - cgroup cgroup rw,cpuset\n")
+	writeCgroupTestFile(t, filepath.Join(leaf, "cpu.cfs_quota_us"), "-1\n")
+	writeCgroupTestFile(t, filepath.Join(leaf, "cpu.cfs_period_us"), "100000\n")
+	writeCgroupTestFile(t, filepath.Join(parent, "cpu.cfs_quota_us"), "50000\n")
+	writeCgroupTestFile(t, filepath.Join(parent, "cpu.cfs_period_us"), "100000\n")
+	writeCgroupTestFile(t, filepath.Join(cpuMount, "cpu.cfs_quota_us"), "100000\n")
+	writeCgroupTestFile(t, filepath.Join(cpuMount, "cpu.cfs_period_us"), "100000\n")
+	writeCgroupTestFile(t, filepath.Join(cpusetMount, "workloads", "collector", "cpuset.cpus"), "0-3\n")
+
+	capacity, err := newCgroupCPUCapacityReaderWithRoots(cgroupRoot, procRoot).Capacity()
+
+	require.NoError(t, err)
+	assert.InDelta(t, 0.5, capacity.EffectiveCores, 0.0001)
+	assert.Equal(t, cpuCapacitySourceCgroupV1Quota, capacity.Source)
+}
+
+func TestCgroupCPUCapacitySupportsNamespacedMountRoot(t *testing.T) {
+	cgroupRoot, procRoot := newTestCgroupRoots(t)
+	writeCgroupTestFile(t, filepath.Join(procRoot, "self", "cgroup"), "0::/\n")
+	writeCgroupTestFile(t, filepath.Join(procRoot, "self", "mountinfo"),
+		"36 25 0:32 /kubepods/pod1/container1 /sys/fs/cgroup rw - cgroup2 cgroup rw\n")
+	writeCgroupTestFile(t, filepath.Join(cgroupRoot, "cpu.max"), "10000 100000\n")
+
+	capacity, err := newCgroupCPUCapacityReaderWithRoots(cgroupRoot, procRoot).Capacity()
+
+	require.NoError(t, err)
+	assert.InDelta(t, 0.1, capacity.EffectiveCores, 0.0001)
+	assert.Equal(t, cpuCapacitySourceCgroupV2Quota, capacity.Source)
+}
+
+func TestCgroupCPUCapacityUsesCPUSetWhenTighter(t *testing.T) {
+	reader, cgroupLeaf := newTestCgroupCapacityReader(t, 2, 4)
+	writeCgroupTestFile(t, filepath.Join(cgroupLeaf, "cpuset.cpus.effective"), "2\n")
+
+	capacity, err := reader.Capacity()
+
+	require.NoError(t, err)
+	assert.InDelta(t, 1, capacity.EffectiveCores, 0.0001)
+	assert.Equal(t, cpuCapacitySourceCgroupV2Set, capacity.Source)
+}
+
+func TestCgroupCPUCapacityDoesNotHideQuotaReadError(t *testing.T) {
+	cgroupRoot, procRoot := newTestCgroupRoots(t)
+	leaf := filepath.Join(cgroupRoot, "service")
+	writeCgroupTestFile(t, filepath.Join(procRoot, "self", "cgroup"), "0::/service\n")
+	writeCgroupTestFile(t, filepath.Join(procRoot, "self", "mountinfo"),
+		"36 25 0:32 / /sys/fs/cgroup rw - cgroup2 cgroup rw\n")
+	require.NoError(t, os.MkdirAll(filepath.Join(leaf, "cpu.max"), 0o755))
+	writeCgroupTestFile(t, filepath.Join(leaf, "cpuset.cpus.effective"), "0-3\n")
+
+	_, err := newCgroupCPUCapacityReaderWithRoots(cgroupRoot, procRoot).Capacity()
+
+	assert.Error(t, err)
+}
+
+func TestCgroupCPUCapacityUnlimitedPreservesConfiguredBudget(t *testing.T) {
+	cgroupRoot, procRoot := newTestCgroupRoots(t)
+	leaf := filepath.Join(cgroupRoot, "service")
+	writeCgroupTestFile(t, filepath.Join(procRoot, "self", "cgroup"), "0::/service\n")
+	writeCgroupTestFile(t, filepath.Join(procRoot, "self", "mountinfo"),
+		"36 25 0:32 / /sys/fs/cgroup rw - cgroup2 cgroup rw\n")
+	writeCgroupTestFile(t, filepath.Join(leaf, "cpu.max"), "max 100000\n")
+
+	reader := newCgroupCPUCapacityReaderWithRoots(cgroupRoot, procRoot)
+	controller, err := newAdaptiveScanController(AdaptiveScanSettings{
+		MinScanFrequency: 100 * time.Millisecond,
+		ScanCPUPercent:   5,
+		ControlInterval:  time.Second,
+	}, reader)
+	require.NoError(t, err)
+
+	snapshot := controller.snapshot()
+	assert.InDelta(t, 0.05, snapshot.TargetDuty, 0.0001)
+	assert.Zero(t, snapshot.EffectiveCores)
+	assert.Equal(t, cpuCapacitySourceUnlimited, snapshot.CPUCapacitySource)
+}
+
+func TestCgroupV1CPUCapacityUnlimitedPreservesConfiguredBudget(t *testing.T) {
+	cgroupRoot, procRoot := newTestCgroupRoots(t)
+	leaf := filepath.Join(cgroupRoot, "cpu", "service")
+	writeCgroupTestFile(t, filepath.Join(procRoot, "self", "cgroup"), "2:cpu,cpuacct:/service\n")
+	writeCgroupTestFile(t, filepath.Join(procRoot, "self", "mountinfo"),
+		"36 25 0:32 / /sys/fs/cgroup/cpu rw - cgroup cgroup rw,cpu,cpuacct\n")
+	writeCgroupTestFile(t, filepath.Join(leaf, "cpu.cfs_quota_us"), "-1\n")
+	writeCgroupTestFile(t, filepath.Join(leaf, "cpu.cfs_period_us"), "100000\n")
+
+	reader := newCgroupCPUCapacityReaderWithRoots(cgroupRoot, procRoot)
+	controller, err := newAdaptiveScanController(AdaptiveScanSettings{
+		MinScanFrequency: 100 * time.Millisecond,
+		ScanCPUPercent:   5,
+		ControlInterval:  time.Second,
+	}, reader)
+	require.NoError(t, err)
+
+	snapshot := controller.snapshot()
+	assert.InDelta(t, 0.05, snapshot.TargetDuty, 0.0001)
+	assert.Zero(t, snapshot.EffectiveCores)
+	assert.Equal(t, cpuCapacitySourceUnlimited, snapshot.CPUCapacitySource)
+}
+
+func TestAdaptiveScanRefreshesRuntimeCPUQuotaAndKeepsLastGoodValue(t *testing.T) {
+	reader, cgroupLeaf := newTestCgroupCapacityReader(t, 2, 0.5)
+	controller, err := newAdaptiveScanController(AdaptiveScanSettings{
+		MinScanFrequency: 100 * time.Millisecond,
+		ScanCPUPercent:   5,
+		ControlInterval:  time.Second,
+	}, reader)
+	require.NoError(t, err)
+	assert.Equal(t, 2*time.Second, controller.NextInterval(1, 30*time.Second, 50*time.Millisecond))
+
+	writeCgroupTestFile(t, filepath.Join(cgroupLeaf, "cpu.max"), "10000 100000\n")
+	controller.updateMultiplier()
+	controller.removeInput(1)
+	controller.updateMultiplier()
+	assert.InDelta(t, 10*time.Second, controller.NextInterval(2, 30*time.Second, 50*time.Millisecond), float64(time.Nanosecond))
+	assert.InDelta(t, 0.005, controller.snapshot().TargetDuty, 0.0001)
+
+	writeCgroupTestFile(t, filepath.Join(cgroupLeaf, "cpu.max"), "invalid\n")
+	assert.Error(t, controller.refreshCPUCapacity())
+	assert.InDelta(t, 0.005, controller.snapshot().TargetDuty, 0.0001)
+}
+
+func TestParseCPUMax(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  float64
+		ok    bool
+	}{
+		{name: "default period", value: "200000", want: 2, ok: true},
+		{name: "explicit period", value: "50000 100000", want: 0.5, ok: true},
+		{name: "unlimited", value: "max 100000"},
+		{name: "zero period", value: "100000 0"},
+		{name: "invalid quota", value: "invalid 100000"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseCPUMax(tt.value)
+			assert.Equal(t, tt.ok, ok)
+			assert.InDelta(t, tt.want, got, 0.0001)
+		})
+	}
+}
+
+func TestCountCPUSet(t *testing.T) {
+	count, err := parseCPUSet("0-2,4,6")
+	require.NoError(t, err)
+	assert.Equal(t, 5, count)
+
+	count, err = parseCPUSet("")
+	require.NoError(t, err)
+	assert.Zero(t, count)
+
+	_, err = parseCPUSet("invalid")
+	assert.Error(t, err)
+}
+
+func newTestCgroupCapacityReader(
+	t *testing.T,
+	version int,
+	quotaCores float64,
+) (*cgroupCPUCapacityReader, string) {
+	t.Helper()
+	cgroupRoot, procRoot := newTestCgroupRoots(t)
+	relative := filepath.Join("workloads", "collector")
+
+	switch version {
+	case 1:
+		cpuMount := filepath.Join(cgroupRoot, "cpu")
+		cpusetMount := filepath.Join(cgroupRoot, "cpuset")
+		writeCgroupTestFile(t, filepath.Join(procRoot, "self", "cgroup"),
+			"2:cpu,cpuacct:/workloads/collector\n3:cpuset:/workloads/collector\n")
+		writeCgroupTestFile(t, filepath.Join(procRoot, "self", "mountinfo"),
+			"36 25 0:32 / /sys/fs/cgroup/cpu rw - cgroup cgroup rw,cpu,cpuacct\n"+
+				"37 25 0:33 / /sys/fs/cgroup/cpuset rw - cgroup cgroup rw,cpuset\n")
+		leaf := filepath.Join(cpuMount, relative)
+		writeCgroupTestFile(t, filepath.Join(leaf, "cpu.cfs_quota_us"),
+			fmt.Sprintf("%.0f\n", quotaCores*100000))
+		writeCgroupTestFile(t, filepath.Join(leaf, "cpu.cfs_period_us"), "100000\n")
+		writeCgroupTestFile(t, filepath.Join(cpusetMount, relative, "cpuset.cpus"), "0-7\n")
+		return newCgroupCPUCapacityReaderWithRoots(cgroupRoot, procRoot), leaf
+	case 2:
+		writeCgroupTestFile(t, filepath.Join(procRoot, "self", "cgroup"), "0::/workloads/collector\n")
+		writeCgroupTestFile(t, filepath.Join(procRoot, "self", "mountinfo"),
+			"36 25 0:32 / /sys/fs/cgroup rw - cgroup2 cgroup rw\n")
+		leaf := filepath.Join(cgroupRoot, relative)
+		writeCgroupTestFile(t, filepath.Join(leaf, "cpu.max"),
+			fmt.Sprintf("%.0f 100000\n", quotaCores*100000))
+		writeCgroupTestFile(t, filepath.Join(leaf, "cpuset.cpus.effective"), "0-7\n")
+		return newCgroupCPUCapacityReaderWithRoots(cgroupRoot, procRoot), leaf
+	default:
+		t.Fatalf("unsupported cgroup version %d", version)
+		return nil, ""
+	}
+}
+
+func newTestCgroupRoots(t *testing.T) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	return filepath.Join(root, "sys", "fs", "cgroup"), filepath.Join(root, "proc")
+}
+
+func writeCgroupTestFile(t *testing.T, filename, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(filename), 0o755))
+	require.NoError(t, os.WriteFile(filename, []byte(content), 0o644))
+}


### PR DESCRIPTION
## Summary

- Read the current process cgroup v1/v2 CPU quota and cpuset, including inherited parent limits and cgroup namespace mount roots.
- Keep the configured single-core scan budget for binary, unlimited, and multi-core deployments; scale it proportionally only when effective CPU capacity is below one core.
- Refresh quota files on every governor cycle so runtime CPU limit changes take effect, while retaining the last valid value on read errors.
- Expose configured/effective target duty, effective cores, and capacity source in adaptive scan diagnostics.

The cgroup discovery and hierarchy handling reuse ideas from the team implementation in [bkmonitor-datalink](https://github.com/TencentBlueKing/bkmonitor-datalink/blob/master/pkg/collector/internal/throttle/cgroup.go), with mountinfo root resolution added for namespaced and bind-mounted layouts.

## Validation

- `go test ./utils ./config ./beater -count=1`
- Targeted `go test -race` for adaptive scan, cgroup capacity, and manager wiring
- Temporary `/proc` + `/sys/fs/cgroup` end-to-end tests for cgroup v1/v2 at 0.1, 0.5, 1, and 2 cores, inherited parent limits, namespace mount roots, cpuset precedence, unlimited quotas, runtime quota changes, and read-error fallback
- Linux amd64 static binary build and Linux/Windows amd64 test-binary compilation
- Native collector process: collected and emitted a real test log through console output, shortened scan interval from 30s to 100ms, reported `target_duty=0.0500` and `cpu_capacity_source=non_linux`, then shut down cleanly via SIGINT

A real Linux container runtime test was not available on this macOS host; container semantics are covered by the injected cgroup integration tests and Linux build, and are not claimed as a runtime-container pass.

## Known baseline / infrastructure issues

- `go test ./...` still has one unrelated pre-existing failure in `config/input.TestNewTaskConfig`: the test hard-codes a six-month duration as 4488h while the current date produces 4344h. Neither that package nor the tested behavior is changed here.
- The GitHub `build` check fails before compilation because the repository workflow pins Go 1.14 while current `master` requires Go 1.24 and a `toolchain` directive. PR #140 has the same baseline failure; this PR intentionally does not mix in a workflow upgrade.
- The internal code-check pipeline failed in `Checkout` with error `800002: http授权失败`; code analysis did not run, so this is recorded as an external authentication failure rather than a code finding.

close #1010158081136436214