### PR TITLE
feat: kafka 采集支持 SASL/SCRAM 认证机制

### DIFF
--- a/bkunifylogbeat.reference.yml
+++ b/bkunifylogbeat.reference.yml
@@ -98,4 +98,38 @@ bkunifylogbeat.local:
           key_name: "event_id"
           regex: "keep records by regex"
 
+  - dataid: 123
+    type: kafka
+    # kafka broker 地址列表
+    hosts: ["kafka-1:9093", "kafka-2:9093"]
+    # 消费的 topic 列表
+    topics: ["logs"]
+    # 消费组，同一 group_id 的多个采集器实例共同分摊 partition
+    group_id: "bkunifylogbeat_123"
+    # 消费组无已提交位点时的起始位置，可选 oldest/newest，默认 newest
+    initial_offset: "newest"
+
+    # SASL 认证：配置 username 后启用，密码必填
+    username: "collector"
+    password: "xxxx"
+    # SASL 机制，可选 PLAIN / SCRAM-SHA-256 / SCRAM-SHA-512（大小写不敏感），
+    # 不配置默认为 PLAIN
+    sasl_mechanism: "SCRAM-SHA-512"
+
+    # TLS 配置：与 SASL 组合即为 SASL_SSL
+    ssl:
+      enabled: true
+      certificate_authorities: ["/etc/bkunifylogbeat/certs/ca.crt"]
+
+    # 消息正文分列分隔符与过滤规则，与文件采集一致
+    delimiter: "|"
+    filters:
+      - conditions:
+          - index: 2
+            key: "ERROR"
+            op: "eq"
+
+    ext_meta:
+      bk_biz_id: "2"
+
 

--- a/config/task_test.go
+++ b/config/task_test.go
@@ -48,6 +48,36 @@ func TestTaskConfig_Same(t *testing.T) {
 	assert.False(t, taskConfig1.Same(taskConfig3))
 }
 
+// TestKafkaTaskConfig 测试kafka任务配置透传
+func TestKafkaTaskConfig(t *testing.T) {
+	vars := map[string]interface{}{
+		"dataid":         "999990001",
+		"type":           "kafka",
+		"hosts":          []string{"kafka-1:9093"},
+		"topics":         []string{"logs"},
+		"group_id":       "bkunifylogbeat_999990001",
+		"username":       "collector",
+		"password":       "secret",
+		"sasl_mechanism": "SCRAM-SHA-512",
+		"initial_offset": "newest",
+	}
+
+	taskConfig, err := CreateTaskConfig(vars)
+	assert.NoError(t, err)
+	assert.Equal(t, "kafka", taskConfig.Type)
+
+	// kafka 专属字段不参与 TaskConfig 结构，需保留在 RawConfig 中透传给 kafka input
+	mechanism, err := taskConfig.RawConfig.String("sasl_mechanism", -1)
+	assert.NoError(t, err)
+	assert.Equal(t, "SCRAM-SHA-512", mechanism)
+
+	var kafkaCfg struct {
+		Hosts []string `config:"hosts"`
+	}
+	assert.NoError(t, taskConfig.RawConfig.Unpack(&kafkaCfg))
+	assert.Equal(t, []string{"kafka-1:9093"}, kafkaCfg.Hosts)
+}
+
 func TestLoadMetaFile(t *testing.T) {
 	f, err := os.CreateTemp("", "meta.file")
 	assert.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -84,6 +84,8 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tklauser/numcpus v0.3.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
+	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
+	github.com/xdg/stringprep v1.0.0 // indirect
 	go.opentelemetry.io/otel v1.16.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.16.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.16.0 // indirect
@@ -116,6 +118,6 @@ require (
 
 replace (
 	github.com/Sirupsen/logrus v1.6.0 => github.com/sirupsen/logrus v1.9.3
-	github.com/elastic/beats v7.1.1+incompatible => github.com/TencentBlueking/beats v7.1.53-bk+incompatible
+	github.com/elastic/beats v7.1.1+incompatible => github.com/TencentBlueking/beats v7.1.56-bk+incompatible
 	github.com/sirupsen/logrus v1.8.1 => github.com/sirupsen/logrus v1.9.3
 )

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse v1.9.1-alpha.1 h1:kJH1O
 github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse v1.9.1-alpha.1/go.mod h1:gDiD8QFEEugzdlgdm7MGPp1szzwgKca0FZkhmTZ67Y0=
 github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils v0.3.0 h1:M22V54nzKf4jReUWp9+rF0255nvlQP/B4zzuXIGyBlU=
 github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils v0.3.0/go.mod h1:ETap19QgROaVGv9E9MRtWMeOgx/gbhbtzcjk4cgadoM=
-github.com/TencentBlueking/beats v7.1.53-bk+incompatible h1:5uzFBednpBEEpL5yhrNA+AdzX3G/aLnSDyNLrtN7qPI=
-github.com/TencentBlueking/beats v7.1.53-bk+incompatible/go.mod h1:tJ6ZFzI1DAUQUUyvPBYVlmGBuH3QKGDK9mwN4LBg+Os=
+github.com/TencentBlueking/beats v7.1.56-bk+incompatible h1:Tr+L4s0wQL/GFRwjpQ31mt9nqRK8K7/GDSeRYXFTJ1E=
+github.com/TencentBlueking/beats v7.1.56-bk+incompatible/go.mod h1:tJ6ZFzI1DAUQUUyvPBYVlmGBuH3QKGDK9mwN4LBg+Os=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -396,7 +396,9 @@ github.com/tklauser/numcpus v0.3.0/go.mod h1:yFGUr7TUHQRAhyqBcEg0Ge34zDBAsIvJJcy
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
+github.com/xdg/stringprep v1.0.0 h1:d9X0esnoa3dFsV0FG35rAT0RIhYFlPq7MiP+DW89La0=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/support-files/templates/aix/powerpc/etc/bkunifylogbeat_kafka.conf.tpl
+++ b/support-files/templates/aix/powerpc/etc/bkunifylogbeat_kafka.conf.tpl
@@ -11,6 +11,9 @@ local: {% for item in local %}
       {% if item.ssl is defined and item.ssl %}ssl: {{ item.ssl }}{% endif %}
       username: '{{ item.get('username', '') }}'
       password: '{{ item.get('password', '') }}'
+      {%- if item.sasl_mechanism is defined and item.sasl_mechanism %}
+      sasl_mechanism: '{{ item.sasl_mechanism }}'
+      {%- endif %}
 
       group_id: '{% if item.group_id is defined and item.group_id %}{{ item.get('group_id') }}{% else %}bkunifylogbeat_{{ dataid | int }}{% endif %}'
 

--- a/support-files/templates/linux/aarch64/etc/bkunifylogbeat_kafka.conf.tpl
+++ b/support-files/templates/linux/aarch64/etc/bkunifylogbeat_kafka.conf.tpl
@@ -11,6 +11,9 @@ local: {% for item in local %}
       {% if item.ssl is defined and item.ssl %}ssl: {{ item.ssl }}{% endif %}
       username: '{{ item.get('username', '') }}'
       password: '{{ item.get('password', '') }}'
+      {%- if item.sasl_mechanism is defined and item.sasl_mechanism %}
+      sasl_mechanism: '{{ item.sasl_mechanism }}'
+      {%- endif %}
 
       group_id: '{% if item.group_id is defined and item.group_id %}{{ item.get('group_id') }}{% else %}bkunifylogbeat_{{ dataid | int }}{% endif %}'
 

--- a/support-files/templates/linux/x86/etc/bkunifylogbeat_kafka.conf.tpl
+++ b/support-files/templates/linux/x86/etc/bkunifylogbeat_kafka.conf.tpl
@@ -11,6 +11,9 @@ local: {% for item in local %}
       {% if item.ssl is defined and item.ssl %}ssl: {{ item.ssl }}{% endif %}
       username: '{{ item.get('username', '') }}'
       password: '{{ item.get('password', '') }}'
+      {%- if item.sasl_mechanism is defined and item.sasl_mechanism %}
+      sasl_mechanism: '{{ item.sasl_mechanism }}'
+      {%- endif %}
 
       group_id: '{% if item.group_id is defined and item.group_id %}{{ item.get('group_id') }}{% else %}bkunifylogbeat_{{ dataid | int }}{% endif %}'
 

--- a/support-files/templates/linux/x86_64/etc/bkunifylogbeat_kafka.conf.tpl
+++ b/support-files/templates/linux/x86_64/etc/bkunifylogbeat_kafka.conf.tpl
@@ -11,6 +11,9 @@ local: {% for item in local %}
       {% if item.ssl is defined and item.ssl %}ssl: {{ item.ssl }}{% endif %}
       username: '{{ item.get('username', '') }}'
       password: '{{ item.get('password', '') }}'
+      {%- if item.sasl_mechanism is defined and item.sasl_mechanism %}
+      sasl_mechanism: '{{ item.sasl_mechanism }}'
+      {%- endif %}
 
       group_id: '{% if item.group_id is defined and item.group_id %}{{ item.get('group_id') }}{% else %}bkunifylogbeat_{{ dataid | int }}{% endif %}'
 

--- a/support-files/templates/windows/x86/etc/bkunifylogbeat_kafka.conf.tpl
+++ b/support-files/templates/windows/x86/etc/bkunifylogbeat_kafka.conf.tpl
@@ -11,6 +11,9 @@ local: {% for item in local %}
       {% if item.ssl is defined and item.ssl %}ssl: {{ item.ssl }}{% endif %}
       username: '{{ item.get('username', '') }}'
       password: '{{ item.get('password', '') }}'
+      {%- if item.sasl_mechanism is defined and item.sasl_mechanism %}
+      sasl_mechanism: '{{ item.sasl_mechanism }}'
+      {%- endif %}
 
       group_id: '{% if item.group_id is defined and item.group_id %}{{ item.get('group_id') }}{% else %}bkunifylogbeat_{{ dataid | int }}{% endif %}'
 

--- a/support-files/templates/windows/x86_64/etc/bkunifylogbeat_kafka.conf.tpl
+++ b/support-files/templates/windows/x86_64/etc/bkunifylogbeat_kafka.conf.tpl
@@ -11,6 +11,9 @@ local: {% for item in local %}
       {% if item.ssl is defined and item.ssl %}ssl: {{ item.ssl }}{% endif %}
       username: '{{ item.get('username', '') }}'
       password: '{{ item.get('password', '') }}'
+      {%- if item.sasl_mechanism is defined and item.sasl_mechanism %}
+      sasl_mechanism: '{{ item.sasl_mechanism }}'
+      {%- endif %}
 
       group_id: '{% if item.group_id is defined and item.group_id %}{{ item.get('group_id') }}{% else %}bkunifylogbeat_{{ dataid | int }}{% endif %}'
 


### PR DESCRIPTION
- 升级 beats 至 v7.1.56-bk，kafka input/output 新增 sasl_mechanism 配置项，支持 PLAIN、SCRAM-SHA-256 和 SCRAM-SHA-512，未配置时保持默认 PLAIN
- 整理 SCRAM 模块依赖，使用 github.com/xdg/scram 和 github.com/xdg/stringprep，并补齐正式版本校验和
- 6 个平台的 kafka 子配置模板按需渲染 sasl_mechanism，不影响未配置该字段的存量任务
- 补充 bkunifylogbeat.reference.yml 中的 kafka 采集与 SASL_SSL 配置说明
- 新增 kafka 任务配置透传单测